### PR TITLE
Antiaffinity View

### DIFF
--- a/k8s-scheduler/src/main/resources/scheduler_tables.sql
+++ b/k8s-scheduler/src/main/resources/scheduler_tables.sql
@@ -323,8 +323,11 @@ join pod_labels
             and pod_anti_affinity_match_expressions.label_value = pod_labels.label_value)
         or (pod_anti_affinity_match_expressions.label_operator = 'Exists'
             and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key)
-        or (pod_anti_affinity_match_expressions.label_operator = 'NotIn')
-        or (pod_anti_affinity_match_expressions.label_operator = 'DoesNotExist')
+        or (pod_anti_affinity_match_expressions.label_operator = 'NotIn'
+        and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
+            and pod_anti_affinity_match_expressions.label_value = pod_labels.label_value)
+        or (pod_anti_affinity_match_expressions.label_operator = 'DoesNotExist'
+            and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key)
 join pod_info
         on pod_labels.pod_name = pod_info.pod_name;
 

--- a/k8s-scheduler/src/main/resources/scheduler_tables.sql
+++ b/k8s-scheduler/src/main/resources/scheduler_tables.sql
@@ -323,13 +323,21 @@ join pod_labels
             and pod_anti_affinity_match_expressions.label_value = pod_labels.label_value)
         or (pod_anti_affinity_match_expressions.label_operator = 'Exists'
             and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key)
-        or (pod_anti_affinity_match_expressions.label_operator = 'NotIn'
-        and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
-            and pod_anti_affinity_match_expressions.label_value = pod_labels.label_value)
-        or (pod_anti_affinity_match_expressions.label_operator = 'DoesNotExist'
-            and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key)
+        or (pod_anti_affinity_match_expressions.label_operator = 'NotIn')
+        or (pod_anti_affinity_match_expressions.label_operator = 'DoesNotExist')
 join pod_info
-        on pod_labels.pod_name = pod_info.pod_name;
+        on pod_labels.pod_name = pod_info.pod_name
+group by pods_to_assign.pod_name,  pod_labels.pod_name, pod_anti_affinity_match_expressions.label_selector,
+         pod_anti_affinity_match_expressions.topology_key, pod_anti_affinity_match_expressions.label_operator,
+         pod_anti_affinity_match_expressions.num_match_expressions, pod_info.node_name
+having case pod_anti_affinity_match_expressions.label_operator
+             when 'NotIn'
+                  then not(any(pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
+                               and pod_anti_affinity_match_expressions.label_value = pod_labels.label_value))
+             when 'DoesNotExist'
+                  then not(any(pod_anti_affinity_match_expressions.label_key = pod_labels.label_key))
+             else count(distinct match_expression) = pod_anti_affinity_match_expressions.num_match_expressions
+       end;
 
 create view inter_pod_anti_affinity_matches as
 select *, count(*) over (partition by pod_name) as num_matches from inter_pod_anti_affinity_matches_inner;

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -591,20 +591,20 @@ public class SchedulerTest {
                 argGen("AntiAffinity", existsTerm, map("k", "l", "k2", "l3"), false, false, false),
 
                 // NotIn
-                argGen("AntiAffinity", notInTerm, map("k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k1", "l2"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k1", "l3"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l2"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l3"), false, false, false),
+                argGen("AntiAffinity", notInTerm, map("k1", "l1"), false, true, false),
+                argGen("AntiAffinity", notInTerm, map("k1", "l2"), false, true, false),
+                argGen("AntiAffinity", notInTerm, map("k1", "l3"), false, false, true),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l1"), false, true, false),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l2"), false, true, false),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l3"), false, false, true),
 
                 // DoesNotExist
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l2"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l3"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, false, false)
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l1"), false, true, false),
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l2"), false, true, false),
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l3"), false, true, false),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, true, false),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, true, false),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, true, false)
 
     );
     }

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -605,7 +605,6 @@ public class SchedulerTest {
                 argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, true, false),
                 argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, true, false),
                 argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, true, false)
-
     );
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -416,9 +416,9 @@ public class SchedulerTest {
                                                    final boolean conditionToRemainingPods,
                                                    final boolean cannotBePlacedAnywhere) {
         final DSLContext conn = Scheduler.setupDb();
-        final int numPods = 10;
+        final int numPods = 4;
         final int numPodsToModify = 3;
-        final int numNodes = 10;
+        final int numNodes = 3;
 
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
         final PodResourceEventHandler handler = new PodResourceEventHandler(conn, emitter);
@@ -591,21 +591,22 @@ public class SchedulerTest {
                 argGen("AntiAffinity", existsTerm, map("k", "l", "k2", "l3"), false, false, false),
 
                 // NotIn
-                argGen("AntiAffinity", notInTerm, map("k1", "l1"), false, true, false),
-                argGen("AntiAffinity", notInTerm, map("k1", "l2"), false, true, false),
+                argGen("AntiAffinity", notInTerm, map("k1", "l1"), false, false, false),
+                argGen("AntiAffinity", notInTerm, map("k1", "l2"), false, false, false),
                 argGen("AntiAffinity", notInTerm, map("k1", "l3"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l1"), false, true, false),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l2"), false, true, false),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l1"), false, false, false),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l2"), false, false, false),
                 argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l3"), false, false, false),
 
                 // DoesNotExist
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l1"), false, true, false),
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l2"), false, true, false),
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l3"), false, true, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, true, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, true, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, true, false)
-        );
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l1"), false, false, false),
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l2"), false, false, false),
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l3"), false, false, false),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, false, false),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, false, false),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, false, false)
+
+    );
     }
 
     private static Arguments argGen(final String scenario, final List<PodAffinityTerm> terms,

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -605,7 +605,7 @@ public class SchedulerTest {
                 argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, true, false),
                 argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, true, false),
                 argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, true, false)
-    );
+        );
     }
 
     private static Arguments argGen(final String scenario, final List<PodAffinityTerm> terms,


### PR DESCRIPTION
The anti affinity view should check labels before doing a join for operators 'NotIn' and 'DoesNotExist'.

I decreased the number of pods and nodes to make the test easier to debug.

I had to update the tests to make the change work, but I think the update works: the pods are anti-affine to all labels that are not in `k1: l1` or `k1: l2`. All pods have labels `k1: l3`,  `k: l` or `dummyKey: dummyValue`. Thus, all pods are anti-affine to each other and as there are more pods than nodes, we can't place them anywhere.