### PR TITLE
Cumulative constraints

### DIFF
--- a/build-common/src/main/resources/findbugs-exclude.xml
+++ b/build-common/src/main/resources/findbugs-exclude.xml
@@ -33,6 +33,10 @@
         <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
     </Match>
     <Match>
+        <Class name="org.dcm.backend.OrToolsSolver"/>
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+    <Match>
         <Class name="org.dcm.Scheduler" />
         <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
     </Match>

--- a/dcm/pom.xml
+++ b/dcm/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.google</groupId>
             <artifactId>ortools</artifactId>
-            <version>7.4</version>
+            <version>7.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/dcm/src/main/java/org/dcm/Model.java
+++ b/dcm/src/main/java/org/dcm/Model.java
@@ -413,6 +413,7 @@ public class Model {
      * Scans tables to update the data associated with the model
      */
     private void updateDataFields() {
+        final long updateData = System.nanoTime();
         for (final Map.Entry<Table<? extends Record>, IRTable> entry : jooqTableToIRTable.entrySet()) {
             final Table<? extends Record> table = entry.getKey();
             final IRTable irTable = entry.getValue();
@@ -424,7 +425,6 @@ public class Model {
             LOG.info("updateDataFields for table {} took {}ns to fetch from DB, and {}ns to reflect in IRTables",
                      table.getName(), (select - start), (System.nanoTime() - updateValues));
         }
-        final long updateData = System.nanoTime();
         compiler.updateData(irContext, backend);
         LOG.info("compiler.updateData() took {}ns to complete", (System.nanoTime() - updateData));
     }

--- a/dcm/src/main/java/org/dcm/backend/DetectCapacityConstraints.java
+++ b/dcm/src/main/java/org/dcm/backend/DetectCapacityConstraints.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package org.dcm.backend;
+
+import org.dcm.compiler.monoid.Expr;
+import org.dcm.compiler.monoid.MonoidFunction;
+import org.dcm.compiler.monoid.MonoidVisitor;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+class DetectCapacityConstraints  extends MonoidVisitor<Void, Void>  {
+    final List<MonoidFunction> nodes = new ArrayList<>();
+
+    @Nullable
+    @Override
+    protected Void visitMonoidFunction(final MonoidFunction node, @Nullable final Void context) {
+        if (node.getFunction().equals(MonoidFunction.Function.CAPACITY_CONSTRAINT)) {
+            nodes.add(node);
+        }
+        return super.visitMonoidFunction(node, context);
+    }
+
+    public static List<MonoidFunction> apply(final Expr expr) {
+        final DetectCapacityConstraints visitor = new DetectCapacityConstraints();
+        visitor.visit(expr);
+        return visitor.nodes;
+    }
+}

--- a/dcm/src/main/java/org/dcm/backend/InferType.java
+++ b/dcm/src/main/java/org/dcm/backend/InferType.java
@@ -103,7 +103,11 @@ class InferType extends MonoidVisitor<String, Void> {
     @Nullable
     @Override
     protected String visitMonoidFunction(final MonoidFunction node, @Nullable final Void context) {
-        return visit(node.getArgument(), context);
+        if (node.getFunction().equals(MonoidFunction.Function.CAPACITY_CONSTRAINT)) {
+            return "IntVar";
+        }
+        Preconditions.checkArgument(node.getArgument().size() == 1);
+        return visit(node.getArgument().get(0), context);
     }
 
     @Nullable

--- a/dcm/src/main/java/org/dcm/backend/MinizincCodeGenerator.java
+++ b/dcm/src/main/java/org/dcm/backend/MinizincCodeGenerator.java
@@ -565,7 +565,8 @@ public class MinizincCodeGenerator extends MonoidVisitor<Void, Void> {
                     operands.push(op);
                 } else {
                     // We're usually here because of unary operators like -(count(col1)) in select expressions.
-                    final Expr argument = function.getArgument();
+                    Preconditions.checkArgument(function.getArgument().size() == 1);
+                    final Expr argument = function.getArgument().get(0);
                     final String argumentAsString = evaluateHeadItem(argument, groupByInnerComprehensionQualifier);
                     final String op = String.format("%s(%s)", functionName, argumentAsString);
                     operands.push(op);
@@ -625,7 +626,8 @@ public class MinizincCodeGenerator extends MonoidVisitor<Void, Void> {
                 if (literals.get(0) instanceof MonoidFunction) {
                     final MinizincCodeGenerator cg = new MinizincCodeGenerator(viewName);
                     final MonoidFunction function = (MonoidFunction) literals.get(0);
-                    cg.visit(function.getArgument());
+                    Preconditions.checkArgument(function.getArgument().size() == 1);
+                    cg.visit(function.getArgument().get(0));
                     return ImmutableList.of(String.format("%s(%s)", function.getFunction(),
                                                                              cg.evaluateExpression().get(0)));
                 }
@@ -854,7 +856,8 @@ public class MinizincCodeGenerator extends MonoidVisitor<Void, Void> {
              */
         }
         else if (expr instanceof MonoidFunction) {
-            return usesControllableVariables(((MonoidFunction) expr).getArgument());
+            Preconditions.checkArgument(((MonoidFunction) expr).getArgument().size() == 1);
+            return usesControllableVariables(((MonoidFunction) expr).getArgument().get(0));
         }
         else if (expr instanceof BinaryOperatorPredicate) {
             final BinaryOperatorPredicate predicate = (BinaryOperatorPredicate) expr;

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -8,21 +8,15 @@ package org.dcm.backend;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import com.google.ortools.sat.CpModel;
-import com.google.ortools.sat.CpSolver;
-import com.google.ortools.sat.CpSolverStatus;
 import com.google.ortools.sat.IntVar;
 import com.google.ortools.sat.IntervalVar;
 import com.google.ortools.sat.LinearExpr;
 import com.google.ortools.sat.Literal;
 import com.google.ortools.util.Domain;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class Ops {
     private final CpModel model;
@@ -452,7 +446,7 @@ public class Ops {
                     model.newConstant(1), nodeIntervalEnd[i], "");
         }
 
-        int maxCapacity1 = Ints.max(nodeCapacities1);
+        final int maxCapacity1 = Ints.max(nodeCapacities1);
 
         // 2. Capacity constraints
         model.addCumulative(tasksIntervals, taskDemands1, model.newConstant(maxCapacity1));

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -16,7 +16,6 @@ import com.google.ortools.sat.Literal;
 import com.google.ortools.util.Domain;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -442,7 +441,6 @@ public class Ops {
         final IntervalVar[] tasksIntervals = new IntervalVar[numTasks + capacities.get(0).size()];
 
         final long[] domainArr = domain.stream().mapToLong(encoder::toLong).toArray();
-        System.out.println(Arrays.toString(domainArr));
         final Domain domainT = Domain.fromValues(domainArr);
 
         for (int i = 0; i < numTasks; i++) {
@@ -485,9 +483,6 @@ public class Ops {
         final List<int[]> taskDemands =
                 updatedDemands.stream().map(vec -> vec.stream().mapToInt(Integer::intValue).toArray())
                         .collect(Collectors.toList());
-        taskDemands.forEach(
-                e -> System.out.println(Arrays.toString(e))
-        );
 
         // 2. Capacity constraints
         for (int i = 0; i < numResources; i++) {

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -492,7 +492,7 @@ public class Ops {
         // Cumulative score
         final IntVar[] maximumOfEachResource = new IntVar[numResources];
         for (int i = 0; i < numResources; i++) {
-            final IntVar max = model.newIntVar(0, 10000000, "");
+            final IntVar max = model.newIntVar(0, Integer.MAX_VALUE, "");
             model.addCumulative(tasksIntervals, taskDemands.get(i), max);
             maximumOfEachResource[i] = max;
         }

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -430,16 +430,16 @@ public class Ops {
     }
 
     public void capacityConstraint(final List<IntVar> varsToAssign, final List<String> domain,
-                                   final List<Integer> demands, final List<Integer> capacities) {
+                                   final List<List<Integer>> demands, final List<List<Integer>> capacities) {
         // Create the variables.
-        Preconditions.checkArgument(domain.size() == capacities.size());
+        Preconditions.checkArgument(domain.size() == capacities.get(0).size());
         final IntVar[] taskToNodeAssignment = varsToAssign.toArray(IntVar[]::new);
         final int numTasks = taskToNodeAssignment.length;
         final IntVar[] nodeIntervalEnd = new IntVar[numTasks];
         final IntervalVar[] tasksIntervals = new IntervalVar[numTasks];
 
-        final int[] taskDemands1 = demands.stream().mapToInt(Integer::intValue).toArray();
-        final int[] nodeCapacities1 = capacities.stream().mapToInt(Integer::intValue).toArray();
+        final int[] taskDemands1 = demands.get(0).stream().mapToInt(Integer::intValue).toArray();
+        final int[] nodeCapacities1 = capacities.get(0).stream().mapToInt(Integer::intValue).toArray();
         final long[] domainArr = domain.stream().mapToLong(encoder::toLong).toArray();
         final Domain domainT = Domain.fromValues(domainArr);
 

--- a/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
@@ -1196,8 +1196,8 @@ public class OrToolsSolver implements ISolverBackend {
                     throw new IllegalStateException("Unreachable");
                 case COUNT:
                     // In these cases, it is safe to replace count(argument) with sum(1)
-                    if ((node.getArgument() instanceof MonoidLiteral ||
-                         node.getArgument() instanceof ColumnIdentifier)) {
+                    if ((node.getArgument().get(0) instanceof MonoidLiteral ||
+                         node.getArgument().get(0) instanceof ColumnIdentifier)) {
                         // TODO: another sign that groupContext/subQueryContext should be handled by ExprContext
                         //  and scopes
                         final String scanOver = currentSubQueryContext == null ?

--- a/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
@@ -1135,8 +1135,7 @@ public class OrToolsSolver implements ISolverBackend {
             }
         );
         context.leaveScope();
-        Preconditions.checkArgument(vars.size() == 1 && domain.size() == 1
-                                    && demands.size() == 2 && capacities.size() == 2);
+        Preconditions.checkArgument(vars.size() == 1 && domain.size() == 1);
         final String varsParameterStr = vars.iterator().next();
         final String domainParameterStr = domain.iterator().next();
         final String demandsParameterStr = String.join(", ", demands);

--- a/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
@@ -1625,7 +1625,7 @@ public class OrToolsSolver implements ISolverBackend {
      * @param variableType the type of `variableToExtract`
      * @return the name of the list being extracted
      */
-    private String extractListFromLoop(final String variableToExtract, final OutputIR.Block outerBlock,
+    private  String extractListFromLoop(final String variableToExtract, final OutputIR.Block outerBlock,
                                        final String loopBlockName, final String variableType) {
         final OutputIR.Block forLoop = outerBlock.getForLoopByName(loopBlockName);
         return extractListFromLoop(variableToExtract, outerBlock, forLoop, variableType);

--- a/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
@@ -894,6 +894,7 @@ public class OrToolsSolver implements ISolverBackend {
                .addStatement("solver.getParameters().setLogSearchProgress(true)")
                .addStatement("solver.getParameters().setCpModelProbingLevel(0)")
                .addStatement("solver.getParameters().setNumSearchWorkers(4)")
+               .addStatement("solver.getParameters().setMaxTimeInSeconds(1)")
                .addStatement("final $T status = solver.solve(model)", CpSolverStatus.class)
                .beginControlFlow("if (status == CpSolverStatus.FEASIBLE || status == CpSolverStatus.OPTIMAL)")
                .addStatement("final Map<IRTable, Result<? extends Record>> result = new $T<>()", HashMap.class)

--- a/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/org/dcm/backend/OrToolsSolver.java
@@ -70,7 +70,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;

--- a/dcm/src/main/java/org/dcm/backend/RewriteArity.java
+++ b/dcm/src/main/java/org/dcm/backend/RewriteArity.java
@@ -174,7 +174,7 @@ class RewriteArity {
             if (node.getFunction().equals(MonoidFunction.Function.SUM) ||
                     node.getFunction().equals(MonoidFunction.Function.COUNT)) {
                 final Expr oldSumArg = node.getFunction().equals(MonoidFunction.Function.COUNT)
-                        ? new MonoidLiteral<>(1, Integer.class) : node.getArgument();
+                        ? new MonoidLiteral<>(1, Integer.class) : node.getArgument().get(0);
                 final BinaryOperatorPredicateWithAggregate newArgument
                         = new BinaryOperatorPredicateWithAggregate(BinaryOperatorPredicate.Operator.MULTIPLY,
                                                                    oldSumArg, qualifier);

--- a/dcm/src/main/java/org/dcm/backend/RewriteCountFunction.java
+++ b/dcm/src/main/java/org/dcm/backend/RewriteCountFunction.java
@@ -33,7 +33,7 @@ class RewriteCountFunction {
         @Override
         protected Expr visitMonoidFunction(final MonoidFunction function, @Nullable final Void context) {
             if (function.getFunction().equals(MonoidFunction.Function.COUNT)) {
-                if (!(function.getArgument() instanceof ColumnIdentifier)) {
+                if (!(function.getArgument().get(0) instanceof ColumnIdentifier)) {
                     throw new IllegalStateException("RewriteCountFunction is only safe to use on column identifiers");
                 }
                 final MonoidFunction newFunction = new MonoidFunction(MonoidFunction.Function.SUM,

--- a/dcm/src/main/java/org/dcm/compiler/ExpressionTraverser.java
+++ b/dcm/src/main/java/org/dcm/compiler/ExpressionTraverser.java
@@ -72,7 +72,8 @@ class ExpressionTraverser extends DefaultTraversalVisitor<Void, Void> {
     @Override
     protected Void visitFunctionCall(final FunctionCall node, final Void context) {
         if (node.getArguments().size() == 1
-            || (node.getArguments().isEmpty() && "count".equalsIgnoreCase(node.getName().getSuffix()))) {
+            || (node.getArguments().isEmpty() && "count".equalsIgnoreCase(node.getName().getSuffix()))
+            || (node.getArguments().size() == 4 && node.getName().getSuffix().equals("capacity_constraint"))) {
             stack.push(node);
         } else {
             throw new RuntimeException("I don't know what do with the following node: " + node);

--- a/dcm/src/main/java/org/dcm/compiler/ModelCompiler.java
+++ b/dcm/src/main/java/org/dcm/compiler/ModelCompiler.java
@@ -358,16 +358,19 @@ public class ModelCompiler {
                 final Expr function;
                 final String functionNameStr = functionCall.getName().toString().toUpperCase(Locale.US);
                 final MonoidFunction.Function functionType = MonoidFunction.Function.valueOf(functionNameStr);
-                if (functionCall.getArguments().size() == 1) {
-                    final List<Expr> arithmeticExpression =
-                            processArithmeticExpression(functionCall.getArguments().get(0),
-                                                        tablesReferencedInView,
-                                                        isAggregate);
-                    assert arithmeticExpression.size() == 1;
-                    final Expr argument = arithmeticExpression.get(0);
-                    function = new MonoidFunction(functionType, argument);
+                if (functionCall.getArguments().size() >= 1) {
+                    final List<Expr> arguments = functionCall.getArguments().stream()
+                            .map(e -> {
+                                final List<Expr> arithmeticExpression =
+                                        processArithmeticExpression(e,
+                                                tablesReferencedInView,
+                                                isAggregate);
+                                assert arithmeticExpression.size() == 1;
+                                return arithmeticExpression.get(0);
+                            }).collect(Collectors.toList());
+                    function = new MonoidFunction(functionType, arguments);
                 } else if (functionCall.getArguments().isEmpty() &&
-                            "count".equalsIgnoreCase(functionCall.getName().getSuffix())) {
+                        "count".equalsIgnoreCase(functionCall.getName().getSuffix())) {
                     // The presto parser does not consider count(*) as a function with a single
                     // argument "*", but instead treats it as a function without any arguments.
                     // The parser code therefore has this special case behavior when it

--- a/dcm/src/main/java/org/dcm/compiler/monoid/ComprehensionRewriter.java
+++ b/dcm/src/main/java/org/dcm/compiler/monoid/ComprehensionRewriter.java
@@ -79,7 +79,8 @@ public class ComprehensionRewriter<T> extends MonoidVisitor<Expr, T> {
 
     @Override
     protected Expr visitMonoidFunction(final MonoidFunction node, @Nullable final T context) {
-        final Expr arguments = this.visit(node.getArgument());
+        final List<Expr> arguments = node.getArgument().stream().map(this::visit)
+                                         .collect(Collectors.toList());
         final MonoidFunction function =  new MonoidFunction(node.getFunction(), arguments);
         node.getAlias().ifPresent(function::setAlias);
         return function;

--- a/dcm/src/main/java/org/dcm/compiler/monoid/MonoidFunction.java
+++ b/dcm/src/main/java/org/dcm/compiler/monoid/MonoidFunction.java
@@ -7,23 +7,29 @@
 package org.dcm.compiler.monoid;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 public class MonoidFunction extends Expr {
     private final Function function;
-    private final Expr argument;
+    private final List<Expr> argument;
 
     public MonoidFunction(final Function function, final Expr argument) {
+        this.function = function;
+        this.argument = List.of(argument);
+    }
+
+    public MonoidFunction(final Function function, final List<Expr> argument) {
         this.function = function;
         this.argument = argument;
     }
 
     public MonoidFunction(final Function function, final Expr argument, final String alias) {
         this.function = function;
-        this.argument = argument;
+        this.argument = List.of(argument);
         setAlias(alias);
     }
 
-    public Expr getArgument() {
+    public List<Expr> getArgument() {
         return argument;
     }
 
@@ -51,6 +57,7 @@ public class MonoidFunction extends Expr {
         MAX,
         ALL_DIFFERENT,
         ALL_EQUAL,
-        INCREASING
+        INCREASING,
+        CAPACITY_CONSTRAINT
     }
 }

--- a/dcm/src/main/java/org/dcm/compiler/monoid/MonoidVisitor.java
+++ b/dcm/src/main/java/org/dcm/compiler/monoid/MonoidVisitor.java
@@ -65,7 +65,9 @@ public class MonoidVisitor<T, C> {
 
     @Nullable
     protected T visitMonoidFunction(final MonoidFunction node, @Nullable final C context) {
-        node.getArgument().acceptVisitor(this, context);
+        for (final Expr expr: node.getArgument()) {
+            expr.acceptVisitor(this, context);
+        }
         return null;
     }
 

--- a/dcm/src/test/java/org/dcm/backend/OrToolsIntervalsTest.java
+++ b/dcm/src/test/java/org/dcm/backend/OrToolsIntervalsTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2018-2019 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package org.dcm.backend;
+
+import com.google.common.primitives.Ints;
+import com.google.ortools.sat.CpModel;
+import com.google.ortools.sat.CpSolver;
+import com.google.ortools.sat.CpSolverStatus;
+import com.google.ortools.sat.IntVar;
+import com.google.ortools.sat.IntervalVar;
+import com.google.ortools.sat.LinearExpr;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+@EnabledIfEnvironmentVariable(named = "OR_TOOLS_LIB", matches = ".*libjniortools.*")
+public class OrToolsIntervalsTest {
+
+    static {
+        new OrToolsSolver(); // causes or-tools library to be loaded
+    }
+
+    @Test
+    public void testWithIntervals() {
+        final long now = System.currentTimeMillis();
+        // Create the model.
+        final CpModel model = new CpModel();
+
+        // Create the variables.
+        final int numTasks = 5;
+        final int numNodes = 3;
+        final IntVar[] taskToNodeAssignment = new IntVar[numTasks];
+        final IntVar[] nodeIntervalEnd = new IntVar[numTasks];
+        final IntervalVar[] tasksIntervals = new IntervalVar[numTasks];
+
+        final int[] taskDemands1 = new int[numTasks];
+        final int[] taskDemands2 = new int[numTasks];
+        final int[] scores = new int[numTasks];
+
+        final int[] nodeCapacities1 = new int[numNodes];
+        final int[] nodeCapacities2 = new int[numNodes];
+
+        for (int i = 0; i < numTasks; i++) {
+            taskToNodeAssignment[i] = model.newIntVar(0, numNodes - 1, "");
+            nodeIntervalEnd[i] = model.newIntVar(1, numNodes, "");
+
+            // interval with start as taskToNodeAssignment and size of 1
+            tasksIntervals[i] = model.newIntervalVar(taskToNodeAssignment[i],
+                    model.newConstant(1), nodeIntervalEnd[i], "");
+        }
+
+        for (int i = 0; i < numNodes; i++) {
+            nodeCapacities1[i] = ThreadLocalRandom.current().nextInt(400, 600);
+            nodeCapacities2[i] = ThreadLocalRandom.current().nextInt(400, 600);
+        }
+        final int maxCapacity1 = Ints.max(nodeCapacities1);
+        final int maxCapacity2 = Ints.max(nodeCapacities2);
+
+        for (int i = 0; i < numTasks; i++) {
+            if (i == 0) {
+                taskDemands1[i] = 60;
+                taskDemands2[i] = 50;
+            } else {
+                taskDemands1[i] = (ThreadLocalRandom.current().nextInt(10, 50) * 100) / maxCapacity1;
+                taskDemands2[i] = (ThreadLocalRandom.current().nextInt(10, 50) * 100) / maxCapacity2;
+            }
+            scores[i] = taskDemands1[i] + taskDemands2[i];
+        }
+
+        // 1. Symmetry breaking
+        for (int i = 0; i < numTasks - 1; i++) {
+            model.addLessOrEqual(taskToNodeAssignment[i], taskToNodeAssignment[i + 1]);
+        }
+
+        // 2. Capacity constraints
+        model.addCumulative(tasksIntervals, taskDemands1, model.newConstant(maxCapacity1));
+        model.addCumulative(tasksIntervals, taskDemands2, model.newConstant(maxCapacity2));
+
+        // Cumulative score
+        final IntVar max1 = model.newIntVar(0, 10000000, "");
+        model.addCumulative(tasksIntervals, scores, max1);
+        model.minimize(max1);   // minimize max score
+        System.out.println("Model creation: " + (System.currentTimeMillis() - now));
+
+        // Create a solver and solve the model.
+        final CpSolver solver = new CpSolver();
+        solver.getParameters().setNumSearchWorkers(4);
+        solver.getParameters().setLogSearchProgress(true);
+        solver.getParameters().setCpModelProbingLevel(0);
+
+        final CpSolverStatus status = solver.solve(model);
+        if (status == CpSolverStatus.FEASIBLE || status == CpSolverStatus.OPTIMAL) {
+            System.out.println(solver.value(max1));
+            System.out.println(Arrays.toString(taskDemands1));
+            System.out.println(Arrays.toString(taskDemands2));
+            for (int i = 0; i < numNodes; i++) {
+                int sum = 0;
+                for (int j = 0; j < numTasks; j++) {
+                    if (solver.value(taskToNodeAssignment[j]) == i) {
+                        sum += scores[j];
+                        System.out.println(String.format("Node[%s] has task[%s]", i, j));
+                    }
+                }
+                System.out.println(String.format("Node[%s] has score=%s", i, sum));
+            }
+        }
+        System.out.println("Done: " + (System.currentTimeMillis() - now));
+    }
+
+    @Test
+    public void testWithoutIntervals() {
+        final long now = System.currentTimeMillis();
+        // Create the model.
+        final CpModel model = new CpModel();
+
+        // Create the variables.
+        final int numTasks = 50;
+        final int numNodes = 1000;
+        final IntVar[] taskToNodeAssignment = new IntVar[numTasks];
+        final int[] taskDemands1 = new int[numTasks];
+        final int[] taskDemands2 = new int[numTasks];
+        final int[] scores = new int[numTasks];
+
+        final int[] nodeCapacities1 = new int[numNodes];
+        final int[] nodeCapacities2 = new int[numNodes];
+
+        for (int i = 0; i < numTasks; i++) {
+            taskToNodeAssignment[i] = model.newIntVar(0, numNodes - 1, "");
+        }
+        for (int i = 0; i < numTasks; i++) {
+            taskDemands1[i] = ThreadLocalRandom.current().nextInt(1, 5);
+            taskDemands2[i] = ThreadLocalRandom.current().nextInt(1, 5);
+            scores[i] = taskDemands1[i] + taskDemands2[i];
+        }
+        for (int i = 0; i < numNodes; i++) {
+            nodeCapacities1[i] = 500;
+            nodeCapacities2[i] = 600;
+        }
+
+        // 1. Symmetry breaking
+        for (int i = 0; i < numTasks - 1; i++) {
+            model.addLessOrEqual(taskToNodeAssignment[i], taskToNodeAssignment[i + 1]);
+        }
+
+        // 2. Capacity constraint
+        final IntVar[] scoreVars = new IntVar[numNodes];
+        for (int node = 0; node < numNodes; node++) {
+            final IntVar[] tasksOnNode = new IntVar[numTasks];    // indicator whether task is assigned to this node
+            for (int i = 0; i < numTasks; i++) {
+                final IntVar bVar = model.newBoolVar("");
+                model.addEquality(taskToNodeAssignment[i], node).onlyEnforceIf(bVar);
+                model.addDifferent(taskToNodeAssignment[i], node).onlyEnforceIf(bVar.not());
+                tasksOnNode[i] = bVar;
+            }
+            final IntVar load1 = model.newIntVar(0, 10000000, "");
+            final IntVar load2 = model.newIntVar(0, 10000000, "");
+            final IntVar score = model.newIntVar(0, 10000000, "");
+            model.addEquality(load1, LinearExpr.scalProd(tasksOnNode, taskDemands1));  // cpu load = sum of all tasks
+            model.addEquality(load2, LinearExpr.scalProd(tasksOnNode, taskDemands2));  // mem load variable
+            model.addEquality(score, LinearExpr.scalProd(tasksOnNode, scores)); //score variable for this node
+
+            scoreVars[node] = score;
+
+            model.addLessOrEqual(load1, nodeCapacities1[node]);  // capacity constraints
+            model.addLessOrEqual(load2, nodeCapacities2[node]);
+        }
+
+        final IntVar max1 = model.newIntVar(0, 10000000, "");
+        model.addMaxEquality(max1, scoreVars);
+        model.minimize(max1);   // minimize max score
+        System.out.println("Model creation: " + (System.currentTimeMillis() - now));
+
+        // Create a solver and solve the model.
+        final CpSolver solver = new CpSolver();
+        solver.getParameters().setNumSearchWorkers(4);
+        solver.getParameters().setLogSearchProgress(true);
+        solver.getParameters().setCpModelProbingLevel(0);
+
+        final CpSolverStatus status = solver.solve(model);
+        if (status == CpSolverStatus.FEASIBLE || status == CpSolverStatus.OPTIMAL) {
+            System.out.println(solver.value(max1));
+        }
+        System.out.println("Done: " + (System.currentTimeMillis() - now));
+    }
+}

--- a/k8s-scheduler/pom.xml
+++ b/k8s-scheduler/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>4.6.3</version>
+            <version>4.9.0</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>

--- a/k8s-scheduler/src/main/java/org/dcm/KubernetesStateSync.java
+++ b/k8s-scheduler/src/main/java/org/dcm/KubernetesStateSync.java
@@ -20,12 +20,16 @@ import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 class KubernetesStateSync {
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesStateSync.class);
     private final SharedInformerFactory sharedInformerFactory;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     KubernetesStateSync(final KubernetesClient client) {
-        this.sharedInformerFactory = client.informers();
+        this.sharedInformerFactory = client.informers(executorService);
     }
 
     Flowable<PodEvent> setupInformersAndPodEventStream(final DSLContext conn) {
@@ -51,5 +55,6 @@ class KubernetesStateSync {
 
     void shutdown() {
         sharedInformerFactory.stopAllRegisteredInformers();
+        executorService.shutdown();
     }
 }

--- a/k8s-scheduler/src/main/java/org/dcm/KubernetesStateSync.java
+++ b/k8s-scheduler/src/main/java/org/dcm/KubernetesStateSync.java
@@ -7,7 +7,6 @@
 
 package org.dcm;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeList;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -17,21 +16,13 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.reactivex.Flowable;
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.schedulers.Schedulers;
 import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-
 class KubernetesStateSync {
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesStateSync.class);
     private final SharedInformerFactory sharedInformerFactory;
-    private final ThreadFactory namedThreadFactory =
-            new ThreadFactoryBuilder().setNameFormat("flowable-thread-%d").build();
-    private final ExecutorService service = Executors.newFixedThreadPool(10, namedThreadFactory);
 
     KubernetesStateSync(final KubernetesClient client) {
         this.sharedInformerFactory = client.informers();
@@ -51,7 +42,7 @@ class KubernetesStateSync {
 
         LOG.info("Instantiated node and pod informers. Starting them all now.");
 
-        return podEventPublishProcessor.observeOn(Schedulers.from(service));
+        return podEventPublishProcessor;
     }
 
     void startProcessingEvents() {

--- a/k8s-scheduler/src/main/java/org/dcm/Policies.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Policies.java
@@ -142,9 +142,8 @@ class Policies {
             "                           pods_to_assign.cpu_request, spare_capacity_per_node.cpu_remaining) = true" +
             " and capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, " +
             "                         pods_to_assign.memory_request, spare_capacity_per_node.memory_remaining) = true";
-        if (withHardConstraint) {
-            views.add(hardConstraint);
-        }
+        views.add(hardConstraint);
+        // TODO: Add soft constraint only version as well
         return new Policy("CapacityConstraint", views);
     }
 

--- a/k8s-scheduler/src/main/java/org/dcm/Policies.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Policies.java
@@ -141,7 +141,9 @@ class Policies {
             "having capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, " +
             "                           pods_to_assign.cpu_request, spare_capacity_per_node.cpu_remaining) = true" +
             " and capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, " +
-            "                         pods_to_assign.memory_request, spare_capacity_per_node.memory_remaining) = true";
+            "                         pods_to_assign.memory_request, spare_capacity_per_node.memory_remaining) = true" +
+            " and capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, " +
+            "                         pods_to_assign.pods_request, spare_capacity_per_node.pods_remaining) = true";
         views.add(hardConstraint);
         // TODO: Add soft constraint only version as well
         return new Policy("CapacityConstraint", views);

--- a/k8s-scheduler/src/main/java/org/dcm/Policies.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Policies.java
@@ -133,30 +133,34 @@ class Policies {
         // pod per node. If not, those nodes will lack a row in the spare_capacity_per_node view. This is fine for
         // Kubernetes, because there always some system pods running on each node.
         final List<String> views = new ArrayList<>();
-        final String intermediateView = "create view pods_slack_per_node as " +
-            "select sum((pods_to_assign.cpu_request * 100) / spare_capacity_per_node.cpu_remaining) " +
-                "      as cpu_load," +
-            "  sum((pods_to_assign.memory_request * 100) / spare_capacity_per_node.memory_remaining) " +
-                "      as memory_load " +
+        final String hardConstraint = "create view constraint_pods_slack_per_node as " +
+            "select * " +
             "from spare_capacity_per_node " +
             "join pods_to_assign " +
             "     on pods_to_assign.controllable__node_name = spare_capacity_per_node.name " +
-            "group by spare_capacity_per_node.name, spare_capacity_per_node.cpu_remaining, " +
-            "         spare_capacity_per_node.memory_remaining, spare_capacity_per_node.pods_remaining";
-        final String capacityHardConstraint =  "create view constraint_capacity as " +
-                                               "select * from pods_slack_per_node " +
-                                               "where cpu_load <= 100 " +
-                                               "  and memory_load <= 100";
-        final String capacityCpuMemSoftConstraint = "create view objective_least_requested_cpu_mem as " +
-                                                    "select -max(cpu_load + memory_load) " +
-                                                    "from pods_slack_per_node";
-        views.add(intermediateView);
+            "having capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, pods_to_assign.cpu_request, spare_capacity_per_node.cpu_remaining) = true" +
+            " and   capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, pods_to_assign.memory_request, spare_capacity_per_node.memory_remaining) = true ";
+//        final String softConstraint = "create view objective_pods_slack_per_node as " +
+//                "select sum(pods_to_assign.cpu_request + pods_to_assign.memory_request) " +
+//                "from spare_capacity_per_node " +
+//                "join pods_to_assign " +
+//                "     on pods_to_assign.controllable__node_name = spare_capacity_per_node.name " +
+//                "group by spare_capacity_per_node.name, spare_capacity_per_node.cpu_remaining, " +
+//                "         spare_capacity_per_node.memory_remaining";
+//        final String capacityHardConstraint =  "create view constraint_capacity as " +
+//                                               "select * from pods_slack_per_node " +
+//                                               "where cpu_load <= 100 " +
+//                                               "  and memory_load <= 100";
+//        final String capacityCpuMemSoftConstraint = "create view objective_least_requested_cpu_mem as " +
+//                                                    "select -max(cpu_load + memory_load) " +
+//                                                    "from pods_slack_per_node";
+//        views.add(intermediateView);
         if (withHardConstraint) {
-            views.add(capacityHardConstraint);
+            views.add(hardConstraint);
         }
-        if (withSoftConstraint) {
-            views.add(capacityCpuMemSoftConstraint);
-        }
+//        if (withSoftConstraint) {
+//            views.add(softConstraint);
+//        }
         return new Policy("CapacityConstraint", views);
     }
 

--- a/k8s-scheduler/src/main/java/org/dcm/Policies.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Policies.java
@@ -36,7 +36,7 @@ class Policies {
         final String constraint = "create view constraint_controllable_node_name_domain as " +
                                   "select * from pods_to_assign " +
                                   "where controllable__node_name in " +
-                                        "(select name from allowed_nodes)";
+                                        "(select name from spare_capacity_per_node)";
         return new Policy("NodePredicates", constraint);
     }
 

--- a/k8s-scheduler/src/main/java/org/dcm/Policies.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Policies.java
@@ -138,29 +138,13 @@ class Policies {
             "from spare_capacity_per_node " +
             "join pods_to_assign " +
             "     on pods_to_assign.controllable__node_name = spare_capacity_per_node.name " +
-            "having capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, pods_to_assign.cpu_request, spare_capacity_per_node.cpu_remaining) = true" +
-            " and   capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, pods_to_assign.memory_request, spare_capacity_per_node.memory_remaining) = true ";
-//        final String softConstraint = "create view objective_pods_slack_per_node as " +
-//                "select sum(pods_to_assign.cpu_request + pods_to_assign.memory_request) " +
-//                "from spare_capacity_per_node " +
-//                "join pods_to_assign " +
-//                "     on pods_to_assign.controllable__node_name = spare_capacity_per_node.name " +
-//                "group by spare_capacity_per_node.name, spare_capacity_per_node.cpu_remaining, " +
-//                "         spare_capacity_per_node.memory_remaining";
-//        final String capacityHardConstraint =  "create view constraint_capacity as " +
-//                                               "select * from pods_slack_per_node " +
-//                                               "where cpu_load <= 100 " +
-//                                               "  and memory_load <= 100";
-//        final String capacityCpuMemSoftConstraint = "create view objective_least_requested_cpu_mem as " +
-//                                                    "select -max(cpu_load + memory_load) " +
-//                                                    "from pods_slack_per_node";
-//        views.add(intermediateView);
+            "having capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, " +
+            "                           pods_to_assign.cpu_request, spare_capacity_per_node.cpu_remaining) = true" +
+            " and capacity_constraint(pods_to_assign.controllable__node_name, spare_capacity_per_node.name, " +
+            "                         pods_to_assign.memory_request, spare_capacity_per_node.memory_remaining) = true";
         if (withHardConstraint) {
             views.add(hardConstraint);
         }
-//        if (withSoftConstraint) {
-//            views.add(softConstraint);
-//        }
         return new Policy("CapacityConstraint", views);
     }
 

--- a/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
@@ -74,7 +74,6 @@ public final class Scheduler {
             metrics.histogram(name(Scheduler.class, "pods-per-scheduling-attempt"));
     private final Timer updateDataTimes = metrics.timer(name(Scheduler.class, "updateDataTimes"));
     private final Timer solveTimes = metrics.timer(name(Scheduler.class, "solveTimes"));
-    private final Object freezeUpdates = new Object();
     @Nullable private Disposable subscription;
 
     Scheduler(final DSLContext conn, final List<String> policies, final String solverToUse, final boolean debugMode,

--- a/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
@@ -10,7 +10,6 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.github.davidmoten.rx2.flowable.Transformers;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -109,7 +108,8 @@ public final class Scheduler {
                     && podEvent.getPod().getSpec().getSchedulerName().equals(
                     Scheduler.SCHEDULER_NAME)
             )
-            .compose(Transformers.buffer(batchCount, batchTimeMs, TimeUnit.MILLISECONDS))
+//            .compose(Transformers.buffer(batchCount, batchTimeMs, TimeUnit.MILLISECONDS))
+            .buffer(batchTimeMs, TimeUnit.MILLISECONDS, batchCount)
             .filter(podEvents -> !podEvents.isEmpty())
             .observeOn(Schedulers.computation())
             .subscribe(

--- a/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
@@ -45,7 +45,6 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -95,7 +94,6 @@ public final class Scheduler {
                         final long batchTimeMs) {
         final PodEventsToDatabase podEventsToDatabase = new PodEventsToDatabase(conn);
         subscription = eventStream
-            .subscribeOn(Schedulers.from(Executors.newFixedThreadPool(4)))
             .map(podEventsToDatabase::handle)
             .filter(podEvent -> podEvent.getAction().equals(PodEvent.Action.ADDED)
                     && podEvent.getPod().getStatus().getPhase().equals("Pending")

--- a/k8s-scheduler/src/main/java/org/dcm/Utils.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Utils.java
@@ -9,8 +9,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Objects;
 
 class Utils {
 
@@ -30,12 +29,10 @@ class Utils {
     }
 
     static double convertUnit(final Quantity quantity, final String resourceName) {
-        final String res = quantity.getAmount().replaceAll("[a-zA-Z]", "");
+        final String res = quantity.getAmount();
         final double baseAmount = Double.parseDouble(res);
-        final Pattern p = Pattern.compile("[a-zA-Z]+");
-        final Matcher m = p.matcher(quantity.getAmount());
-        if (m.find()) {
-            final String unit = m.group();
+        final String unit = Objects.requireNonNull(quantity.getFormat());
+        if (!unit.equals("")) {
             switch (unit) {
                 case "m":
                 case "Ki":
@@ -57,7 +54,7 @@ class Utils {
             }
         } else {
             if (resourceName.equals("cpu")) {
-                return baseAmount * 1000; // we represent CPU in milli-CPU units.
+                return baseAmount * 1000; // we represent CPU units in milli-cpus
             }
             return baseAmount;
         }

--- a/k8s-scheduler/src/main/resources/log4j2.xml
+++ b/k8s-scheduler/src/main/resources/log4j2.xml
@@ -8,7 +8,7 @@
     <Loggers>
         <Logger name="org.jooq.Constants" additivity="false" level="OFF">
         </Logger>
-        <Logger name="org.dcm.PodResourceEventHandler" additivity="false" level="off">
+        <Logger name="org.dcm.PodResourceEventHandler" additivity="false" level="debug">
             <AppenderRef ref="console" />
         </Logger>
         <Logger name="org.dcm.EmulatedPodDeployer" additivity="false" level="info">

--- a/k8s-scheduler/src/main/resources/scheduler_tables.sql
+++ b/k8s-scheduler/src/main/resources/scheduler_tables.sql
@@ -230,7 +230,7 @@ create table batch_size
 );
 
 create view pods_to_assign as
-select * from pods_to_assign_no_limit limit 100;
+select * from pods_to_assign_no_limit limit 50;
 
 
 -- Pods with port requests

--- a/k8s-scheduler/src/main/resources/scheduler_tables.sql
+++ b/k8s-scheduler/src/main/resources/scheduler_tables.sql
@@ -356,6 +356,13 @@ select * from
     from node_info
     join pod_info
          on pod_info.node_name = node_info.name and pod_info.node_name != 'null'
+    where node_info.unschedulable = false and
+          node_info.memory_pressure = false and
+          node_info.out_of_disk = false and
+          node_info.disk_pressure = false and
+          node_info.pid_pressure = false and
+          node_info.network_unavailable = false and
+          node_info.ready = true
     group by node_info.name, node_info.cpu_allocatable,
              node_info.memory_allocatable, node_info.pods_allocatable)
 where cpu_remaining > 0 and memory_remaining > 0 and pods_remaining > 0;
@@ -381,13 +388,5 @@ select distinct node_name from node_taints;
 
 -- Avoid overloaded nodes or nodes that report being under resource pressure
 create view allowed_nodes as
-select distinct node_info.name from node_info
-join spare_capacity_per_node
-  on spare_capacity_per_node.name = node_info.name
-where node_info.unschedulable = false and
-      node_info.memory_pressure = false and
-      node_info.out_of_disk = false and
-      node_info.disk_pressure = false and
-      node_info.pid_pressure = false and
-      node_info.network_unavailable = false and
-      node_info.ready = true;
+select name
+from spare_capacity_per_node;

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.reactivex.processors.PublishProcessor;
 import org.jooq.DSLContext;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -35,6 +36,7 @@ import java.util.Map;
 class EmulatedClusterTest {
 
     @Test
+    @Disabled
     public void runTraceLocally() throws Exception {
         final DSLContext conn = Scheduler.setupDb();
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -68,7 +68,7 @@ class EmulatedClusterTest {
             pod.getMetadata().setNamespace("kube-system");
             pod.getSpec().getContainers().get(0).getResources().setRequests(resourceRequests);
             pod.getSpec().setNodeName(nodeName);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
         final WorkloadGeneratorIT workloadGeneratorIT = new WorkloadGeneratorIT();
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -74,7 +74,7 @@ class EmulatedClusterTest {
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
         workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
-                          20, 50, 1000);
+                          20, 50, 100);
     }
 
     private Node addNode(final String nodeName, final Map<String, String> labels,

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -74,7 +74,7 @@ class EmulatedClusterTest {
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
         workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
-                          20, 50, 100);
+                          30, 50, 100);
     }
 
     private Node addNode(final String nodeName, final Map<String, String> labels,

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -72,7 +72,7 @@ class EmulatedClusterTest {
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
         workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
-                          100, 50, 100);
+                          100, 50, 100, 1000);
     }
 
     private Node addNode(final String nodeName, final Map<String, String> labels,

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -41,7 +41,7 @@ class EmulatedClusterTest {
         final DSLContext conn = Scheduler.setupDb();
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
         final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
-        final int numNodes = 50;
+        final int numNodes = 1000;
 
         // Add all nodes
         final NodeResourceEventHandler nodeResourceEventHandler = new NodeResourceEventHandler(conn);
@@ -73,7 +73,7 @@ class EmulatedClusterTest {
         final WorkloadGeneratorIT workloadGeneratorIT = new WorkloadGeneratorIT();
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
-        workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
+        workloadGeneratorIT.runTrace(client, "v2-cropped.txt", deployer, "dcm-scheduler",
                           100, 50, 100, 1000000);
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -74,7 +74,7 @@ class EmulatedClusterTest {
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
         workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
-                          100, 50, 100, 1000);
+                          100, 50, 100, 1000000);
     }
 
     private Node addNode(final String nodeName, final Map<String, String> labels,

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -72,7 +72,7 @@ class EmulatedClusterTest {
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
         workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
-                          100, 50, 5);
+                          100, 50, 100);
     }
 
     private Node addNode(final String nodeName, final Map<String, String> labels,

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.reactivex.processors.PublishProcessor;
 import org.jooq.DSLContext;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -36,7 +35,6 @@ import java.util.Map;
 class EmulatedClusterTest {
 
     @Test
-    @Disabled
     public void runTraceLocally() throws Exception {
         final DSLContext conn = Scheduler.setupDb();
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
@@ -74,7 +72,7 @@ class EmulatedClusterTest {
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
         workloadGeneratorIT.runTrace(client, "v1-cropped.txt", deployer, "dcm-scheduler",
-                          30, 50, 100);
+                          100, 50, 5);
     }
 
     private Node addNode(final String nodeName, final Map<String, String> labels,

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
@@ -91,9 +91,8 @@ public class EmulatedPodDeployer implements IPodDeployer {
         @Override
         public void run() {
             LOG.info("Terminating deployment (name:{}, schedulerName:{}) at {}",
-                    deployment.getMetadata().getName(),
-                    deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
-                    System.currentTimeMillis());
+                deployment.getMetadata().getName(), deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
+                System.currentTimeMillis());
             final List<Pod> podsList = pods.get(deployment.getMetadata().getName());
             Preconditions.checkNotNull(podsList);
             for (final Pod pod: podsList) {

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
@@ -76,7 +76,7 @@ public class EmulatedPodDeployer implements IPodDeployer {
                 pod.setSpec(spec);
                 pod.setStatus(status);
                 pods.computeIfAbsent(deploymentName, (k) -> new ArrayList<>()).add(pod);
-                resourceEventHandler.onAdd(pod);
+                resourceEventHandler.onAddSync(pod);
             }
         }
     }
@@ -96,7 +96,7 @@ public class EmulatedPodDeployer implements IPodDeployer {
             final List<Pod> podsList = pods.get(deployment.getMetadata().getName());
             Preconditions.checkNotNull(podsList);
             for (final Pod pod: podsList) {
-                resourceEventHandler.onDelete(pod, false);
+                resourceEventHandler.onDeleteSync(pod, false);
             }
         }
     }

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
@@ -5,6 +5,7 @@
 
 package org.dcm;
 
+import com.google.common.base.Preconditions;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -90,11 +91,14 @@ public class EmulatedPodDeployer implements IPodDeployer {
         @Override
         public void run() {
             LOG.info("Terminating deployment (name:{}, schedulerName:{}) at {}",
-                    deployment.getMetadata().getName(), deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
+                    deployment.getMetadata().getName(),
+                    deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
                     System.currentTimeMillis());
-            pods.get(deployment.getMetadata().getName()).forEach(
-                    e -> resourceEventHandler.onDelete(e, false)
-            );
+            final List<Pod> podsList = pods.get(deployment.getMetadata().getName());
+            Preconditions.checkNotNull(podsList);
+            for (final Pod pod: podsList) {
+                resourceEventHandler.onDelete(pod, false);
+            }
         }
     }
 }

--- a/k8s-scheduler/src/test/java/org/dcm/ITBase.java
+++ b/k8s-scheduler/src/test/java/org/dcm/ITBase.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/k8s-scheduler/src/test/java/org/dcm/ITBase.java
+++ b/k8s-scheduler/src/test/java/org/dcm/ITBase.java
@@ -8,7 +8,9 @@ package org.dcm;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
@@ -46,16 +48,12 @@ public class ITBase {
     }
 
     public void deleteAllRunningPods(final DefaultKubernetesClient client) throws Exception {
-        final List<Deployment> deployments = client.apps().deployments().inNamespace(TEST_NAMESPACE)
-                .list().getItems();
-        for (final Deployment deployment: deployments) {
-            client.apps().deployments().inNamespace(TEST_NAMESPACE).delete(deployment);
-        }
-        final List<Pod> pods = client.pods().inNamespace(TEST_NAMESPACE)
-                .list().getItems();
-        for (final Pod pod: pods) {
-            client.pods().inNamespace(TEST_NAMESPACE).delete(pod);
-        }
+        final DeploymentList deployments = client.apps().deployments().inNamespace(TEST_NAMESPACE)
+                .list();
+        client.resourceList(deployments).inNamespace(TEST_NAMESPACE).withGracePeriod(0).delete();
+        final PodList pods = client.pods().inNamespace(TEST_NAMESPACE)
+                .list();
+        client.resourceList(pods).inNamespace(TEST_NAMESPACE).withGracePeriod(0).delete();
         waitUntil(client, (n) -> hasDrained(client));
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/KubernetesPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/KubernetesPodDeployer.java
@@ -64,8 +64,7 @@ public class KubernetesPodDeployer implements IPodDeployer {
             LOG.info("Terminating deployment (name:{}, schedulerName:{}) with masterUrl {} at {}",
                     deployment.getMetadata().getName(), deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
                     fabricClient.getConfiguration().getMasterUrl(), System.currentTimeMillis());
-            fabricClient.apps().deployments().inNamespace(namespace)
-                    .delete(deployment);
+            fabricClient.resource(deployment).inNamespace(namespace).withGracePeriod(0).delete();
         }
     }
 }

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -36,7 +36,6 @@ import io.fabric8.kubernetes.api.model.Taint;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.reactivex.processors.PublishProcessor;
 import org.dcm.k8s.generated.Tables;
-import org.dcm.k8s.generated.tables.records.NodeInfoRecord;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -62,7 +62,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -1016,9 +1015,8 @@ public class SchedulerTest {
         DebugUtils.dbLoad(conn);
 
         // All pod additions have completed
-        final Scheduler scheduler = new Scheduler(conn, policies, "ORTOOLS", true, "");
+        final Scheduler scheduler = new Scheduler(conn, policies, "MNZ-CHUFFED", true, "");
         final Result<? extends Record> results = scheduler.runOneLoop();
-        System.out.println(results);
     }
 
 
@@ -1039,8 +1037,6 @@ public class SchedulerTest {
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(conn);
         emitter.map(eventHandler::handle).subscribe();
 
-        // We pick a random node from [0, numNodes) to assign all pods to.
-        final int nodeToAssignTo = ThreadLocalRandom.current().nextInt(numNodes);
         for (int i = 0; i < numNodes; i++) {
             nodeResourceEventHandler.onAdd(addNode("n" + i, Collections.emptyMap(),
                                            Collections.emptyList()));

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -1017,6 +1017,7 @@ public class SchedulerTest {
         // All pod additions have completed
         final Scheduler scheduler = new Scheduler(conn, policies, "MNZ-CHUFFED", true, "");
         final Result<? extends Record> results = scheduler.runOneLoop();
+        System.out.println(results);
     }
 
 

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -192,11 +192,11 @@ public class SchedulerTest {
             final String podName = "system-pod-n" + i;
             final Pod pod = newPod(podName, "Running", Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName("n" + i);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         for (int i = 0; i < numPods; i++) {
-            handler.onAdd(newPod("p" + i));
+            handler.onAddSync(newPod("p" + i));
         }
 
         // All pod additions have completed
@@ -249,7 +249,7 @@ public class SchedulerTest {
             } else {
                 podsWithoutLabels.add(podName);
             }
-            handler.onAdd(newPod(podName, "Pending", selectorLabels, Collections.emptyMap()));
+            handler.onAddSync(newPod(podName, "Pending", selectorLabels, Collections.emptyMap()));
         }
 
         // Add all nodes, some of which have both the disk and gpu labels, whereas others only have the disk label
@@ -274,7 +274,7 @@ public class SchedulerTest {
             final String podName = "system-pod-n" + i;
             final Pod pod = newPod(podName, "Running", Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName("n" + i);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         // First, we check if the computed intermediate view is correct
@@ -364,7 +364,7 @@ public class SchedulerTest {
                 pod.getSpec().getAffinity().getNodeAffinity()
                    .setRequiredDuringSchedulingIgnoredDuringExecution(selector);
             }
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         // Add all nodes, some of which have labels described by nodeLabelsInput,
@@ -391,7 +391,7 @@ public class SchedulerTest {
             final String podName = "system-pod-n" + i;
             final Pod pod = newPod(podName, "Running", Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName("n" + i);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         // First, we check if the computed intermediate views are correct
@@ -543,7 +543,7 @@ public class SchedulerTest {
             } else {
                 pod.getMetadata().setLabels(Collections.singletonMap("dummyKey", "dummyValue"));
             }
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         // Add all nodes
@@ -557,7 +557,7 @@ public class SchedulerTest {
             final String podName = "system-pod-n" + i;
             final Pod pod = newPod(podName, "Running", Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName("n" + i);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         final List<String> policies = Policies.from(Policies.nodePredicates(),
@@ -761,7 +761,7 @@ public class SchedulerTest {
             pod.getSpec().getContainers().get(0)
                 .getResources()
                 .setRequests(resourceRequests);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         // Add all nodes and one system pod per node
@@ -780,7 +780,7 @@ public class SchedulerTest {
             final String status = "Running";
             pod = newPod(podName, status, Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName(nodeName);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         final List<String> policies = Policies.from(Policies.nodePredicates(),
@@ -857,7 +857,7 @@ public class SchedulerTest {
             if (tolerations.get(i).size() != 0) {
                 pod.getSpec().setTolerations(tolerations.get(i));
             }
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         // Add all nodes
@@ -872,7 +872,7 @@ public class SchedulerTest {
             final String podName = "system-pod-n" + i;
             final Pod pod = newPod(podName, "Running", Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName("n" + i);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
         final List<String> policies = Policies.from(Policies.nodePredicates(),
                                                     Policies.taintsAndTolerations());
@@ -1049,11 +1049,11 @@ public class SchedulerTest {
             final String podName = "system-pod-n" + i;
             final Pod pod = newPod(podName, "Running", Collections.emptyMap(), Collections.emptyMap());
             pod.getSpec().setNodeName("n" + i);
-            handler.onAdd(pod);
+            handler.onAddSync(pod);
         }
 
         for (int i = 0; i < numPods; i++) {
-            handler.onAdd(newPod("p" + i));
+            handler.onAddSync(newPod("p" + i));
         }
 
         // All pod additions have completed

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -769,7 +769,8 @@ public class SchedulerTest {
         for (int i = 0; i < numNodes; i++) {
             final String nodeName = "n" + i;
             final Node node = addNode(nodeName, Collections.emptyMap(), Collections.emptyList());
-            node.getStatus().getCapacity().put("cpu", new Quantity(String.valueOf(nodeCpuCapacities.get(i))));
+            node.getStatus().getCapacity().put("cpu",
+                                               new Quantity(String.valueOf(nodeCpuCapacities.get(i))));
             node.getStatus().getCapacity().put("memory", new Quantity(String.valueOf(nodeMemoryCapacities.get(i))));
             nodeResourceEventHandler.onAdd(node);
 
@@ -786,6 +787,8 @@ public class SchedulerTest {
                                                     Policies.capacityConstraint(useHardConstraint, useSoftConstraint));
         final Scheduler scheduler = new Scheduler(conn, policies, "ORTOOLS", true, "");
         if (feasible) {
+            System.out.println(conn.selectFrom(Tables.PODS_TO_ASSIGN).fetch());
+            System.out.println(conn.selectFrom(Tables.NODE_INFO).fetch());
             final Result<? extends Record> result = scheduler.runOneLoop();
             assertEquals(numPods, result.size());
             final List<String> nodes = result.stream()
@@ -1146,7 +1149,7 @@ public class SchedulerTest {
         final Node node = new Node();
         final NodeStatus status = new NodeStatus();
         final Map<String, Quantity> quantityMap = new HashMap<>();
-        quantityMap.put("cpu", new Quantity("10"));
+        quantityMap.put("cpu", new Quantity("10", "m"));
         quantityMap.put("memory", new Quantity("1000"));
         quantityMap.put("ephemeral-storage", new Quantity("1000"));
         quantityMap.put("pods", new Quantity("100"));

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -36,6 +36,7 @@ import io.fabric8.kubernetes.api.model.Taint;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.reactivex.processors.PublishProcessor;
 import org.dcm.k8s.generated.Tables;
+import org.dcm.k8s.generated.tables.records.NodeInfoRecord;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -220,7 +220,7 @@ class WorkloadGeneratorIT extends ITBase {
                 // get duration based on start and end times
                 final int duration = getDuration(start, end);
 
-                final long computedEndTime = Math.min(60, (waitTime / 1000) + duration);
+                final long computedEndTime = Math.min(30, (waitTime / 1000) + duration);
                 // Schedule deletion of this deployment based on duration + time until start of the dep
                 final ScheduledFuture scheduledEnd = scheduledExecutorService.schedule(
                      deployer.endDeployment(deployment), computedEndTime, TimeUnit.SECONDS);

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -180,7 +180,7 @@ class WorkloadGeneratorIT extends ITBase {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final InputStream inStream = classLoader.getResourceAsStream(fileName);
         Preconditions.checkNotNull(inStream);
-        int limit = 10000;
+        int limit = 2000;
 
         long maxStart = 0;
         long maxEnd = 0;

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -57,6 +57,8 @@ class WorkloadGeneratorIT extends ITBase {
     private static final int MEM_SCALE_DOWN_DEFAULT = 50;
     private static final String TIME_SCALE_DOWN_PROPERTY = "timeScaleDown";
     private static final int TIME_SCALE_DOWN_DEFAULT = 1000;
+    private static final String START_TIME_CUTOFF = "startTimeCutOff";
+    private static final int START_TIME_CUTOFF_DEFAULT = 1000;
 
     private final List<ListenableFuture<?>> deletions = new ArrayList<>();
     private final ListeningScheduledExecutorService scheduledExecutorService =
@@ -167,11 +169,17 @@ class WorkloadGeneratorIT extends ITBase {
         final String timeScaleProperty = System.getProperty(TIME_SCALE_DOWN_PROPERTY);
         final int timeScaleDown = timeScaleProperty == null ? TIME_SCALE_DOWN_DEFAULT :
                                         Integer.parseInt(timeScaleProperty);
-        runTrace(fabricClient, fileName, deployer, schedulerName, cpuScaleDown, memScaleDown, timeScaleDown);
+
+        final String startTimeCutOffProperty = System.getProperty(START_TIME_CUTOFF);
+        final int startTimeCutOff = startTimeCutOffProperty == null ? START_TIME_CUTOFF_DEFAULT :
+                Integer.parseInt(startTimeCutOffProperty);
+        runTrace(fabricClient, fileName, deployer, schedulerName, cpuScaleDown, memScaleDown, timeScaleDown,
+                 startTimeCutOff);
     }
 
     void runTrace(final DefaultKubernetesClient client, final String fileName, final IPodDeployer deployer,
-                  final String schedulerName, final int cpuScaleDown, final int memScaleDown, final int timeScaleDown)
+                  final String schedulerName, final int cpuScaleDown, final int memScaleDown, final int timeScaleDown,
+                  final int startTimeCutOff)
             throws Exception {
         assertNotNull(schedulerName);
         LOG.info("Running trace with parameters: SchedulerName:{} CpuScaleDown:{}" +
@@ -204,7 +212,7 @@ class WorkloadGeneratorIT extends ITBase {
                 final Deployment deployment = getDeployment(client, schedulerName, cpu, mem, vmCount, taskCount);
                 totalPods += deployment.getSpec().getReplicas();
 
-                if (Integer.parseInt(parts[2]) > 86400) { // 24 hour window
+                if (Integer.parseInt(parts[2]) > startTimeCutOff) { // window in seconds
                     break;
                 }
                 // get task time info

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -207,9 +207,9 @@ class WorkloadGeneratorIT extends ITBase {
                 final String[] parts = line.split(" ", 7);
                 final int start = Integer.parseInt(parts[2]) / timeScaleDown;
                 final int end = Integer.parseInt(parts[3]) / timeScaleDown;
-                final float cpu = Float.parseFloat(parts[4]) / cpuScaleDown;
-                final float mem = Float.parseFloat(parts[5]) / memScaleDown;
-                final int vmCount = Integer.parseInt(parts[6]);
+                final float cpu = Float.parseFloat(parts[4].replace(">", "")) / cpuScaleDown;
+                final float mem = Float.parseFloat(parts[5].replace(">", "")) / memScaleDown;
+                final int vmCount = Integer.parseInt(parts[6].replace(">", ""));
 
                 // generate a deployment's details based on cpu, mem requirements
                 final Deployment deployment = getDeployment(client, schedulerName, cpu, mem, vmCount, taskCount);

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -203,6 +203,9 @@ class WorkloadGeneratorIT extends ITBase {
                 final Deployment deployment = getDeployment(client, schedulerName, cpu, mem, vmCount, taskCount);
                 totalPods += deployment.getSpec().getReplicas();
 
+                if (Integer.parseInt(parts[2]) > 86400) { // 24 hour window
+                    break;
+                }
                 // get task time info
                 final long taskStartTime = (long) start * 1000; // converting to millisec
                 final long currentTime = System.currentTimeMillis();
@@ -217,12 +220,13 @@ class WorkloadGeneratorIT extends ITBase {
                 // get duration based on start and end times
                 final int duration = getDuration(start, end);
 
+                final long computedEndTime = Math.min(60, (waitTime / 1000) + duration);
                 // Schedule deletion of this deployment based on duration + time until start of the dep
                 final ScheduledFuture scheduledEnd = scheduledExecutorService.schedule(
-                        deployer.endDeployment(deployment), (waitTime / 1000) + duration, TimeUnit.SECONDS);
+                     deployer.endDeployment(deployment), computedEndTime, TimeUnit.SECONDS);
 
                 maxStart = Math.max(maxStart, waitTime / 1000);
-                maxEnd = Math.max(maxEnd, (waitTime / 1000) + duration);
+                maxEnd = Math.max(maxEnd, computedEndTime);
 
                 // Add to a list to enable keeping the test active until deletion
                 endDepList.add(scheduledEnd);

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -253,7 +253,7 @@ class WorkloadGeneratorIT extends ITBase {
                  " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart,
                 maxEnd, maxStart);
 
-        Thread.sleep((maxEnd + 30) * 1000);
+        Thread.sleep((maxStart + 30) * 1000);
         deleteAllRunningPods(client);
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -234,10 +234,10 @@ class WorkloadGeneratorIT extends ITBase {
         }
 
         LOG.info("All tasks launched ({} pods total). The latest application will start at {}s, and the last deletion" +
-                 " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart / 1000,
-                maxEnd, maxStart / 100);
+                 " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart,
+                maxEnd, maxStart);
 
-        Thread.sleep((long) maxStart + 60000);
+        Thread.sleep((maxStart + 600) * 1000);
         deleteAllRunningPods(client);
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -180,7 +180,7 @@ class WorkloadGeneratorIT extends ITBase {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final InputStream inStream = classLoader.getResourceAsStream(fileName);
         Preconditions.checkNotNull(inStream);
-        int limit = 2000;
+        int limit = 10000;
 
         long maxStart = 0;
         long maxEnd = 0;

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -183,7 +183,8 @@ class WorkloadGeneratorIT extends ITBase {
             throws Exception {
         assertNotNull(schedulerName);
         LOG.info("Running trace with parameters: SchedulerName:{} CpuScaleDown:{}" +
-                 " MemScaleDown:{} TimeScaleDown:{}", schedulerName, cpuScaleDown, memScaleDown, timeScaleDown);
+                 " MemScaleDown:{} TimeScaleDown:{} StartTimeCutOff:{}", schedulerName, cpuScaleDown, memScaleDown,
+                                                                      timeScaleDown, startTimeCutOff);
 
         // Load data from file
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -229,7 +229,7 @@ class WorkloadGeneratorIT extends ITBase {
                 // get duration based on start and end times
                 final int duration = getDuration(start, end);
 
-                final long computedEndTime = Math.min(30, (waitTime / 1000) + duration);
+                final long computedEndTime = (waitTime / 1000) + Math.min(30, duration);
 
                 // Schedule deletion of this deployment based on duration + time until start of the dep
                 scheduledStart.addListener(() -> {
@@ -251,9 +251,9 @@ class WorkloadGeneratorIT extends ITBase {
 
         LOG.info("All tasks launched ({} pods total). The latest application will start at {}s, and the last deletion" +
                  " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart,
-                maxEnd, maxStart);
+                maxEnd, maxEnd);
 
-        Thread.sleep((maxStart + 30) * 1000);
+        Thread.sleep((maxEnd + 30) * 1000);
         deleteAllRunningPods(client);
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -253,7 +253,7 @@ class WorkloadGeneratorIT extends ITBase {
                  " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart,
                 maxEnd, maxStart);
 
-        Thread.sleep((maxStart + 600) * 1000);
+        Thread.sleep((maxEnd + 30) * 1000);
         deleteAllRunningPods(client);
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -6,6 +6,7 @@
 package org.dcm;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -253,8 +254,8 @@ class WorkloadGeneratorIT extends ITBase {
                  " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart,
                 maxEnd, maxEnd);
 
-        Thread.sleep((maxEnd + 30) * 1000);
-        deleteAllRunningPods(client);
+        final List<Object> objects = Futures.successfulAsList(deletions).get();
+        assert objects.size() != 0;
     }
 
     private Deployment getDeployment(final DefaultKubernetesClient client, final String schedulerName, final float cpu,

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -235,7 +235,7 @@ class WorkloadGeneratorIT extends ITBase {
                 scheduledStart.addListener(() -> {
                     final ListenableScheduledFuture<?> deletion =
                             scheduledExecutorService.schedule(deployer.endDeployment(deployment),
-                            computedEndTime, TimeUnit.SECONDS);
+                            30, TimeUnit.SECONDS);
                     deletions.add(deletion);
                 }, scheduledExecutorService);
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Computing joins on variable columns based on aggregate constraints, as is typical for capacity constraints, is quite expensive in that it introduces several intermediate boolean variables. We can simplify this by using a decomposition based on intervals and cumulative constraints. Doing so dramatically speeds up and scales solve times when tested in the Kubernetes context.