### PR TITLE
Perf improvements

### DIFF
--- a/benchmarks/src/main/java/org/dcm/BatchTests.java
+++ b/benchmarks/src/main/java/org/dcm/BatchTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package org.dcm;
+
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.NodeAffinity;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import org.dcm.k8s.generated.Tables;
+import org.dcm.k8s.generated.tables.records.PodInfoRecord;
+import org.jooq.DSLContext;
+import org.jooq.UpdateConditionStep;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class BatchTests {
+
+    @Param({"1", "5", "10", "50"})
+    static int numPods;
+
+    @Param({"true", "false"})
+    static boolean useParallelStream;
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        final DBConnectionPool dbConnectionPool = new DBConnectionPool();
+        final PodEventsToDatabase podEventsToDatabase = new PodEventsToDatabase(dbConnectionPool);
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            for (int i = 0; i < 10000; i++) {
+                final Pod pod = newPod("pod-" + i, "Pending", Collections.emptyMap(),
+                                        Collections.emptyMap());
+                final PodEvent event = new PodEvent(PodEvent.Action.ADDED, pod);
+                podEventsToDatabase.handle(event);
+            }
+        }
+
+
+        private Pod newPod(final String podName, final String phase, final Map<String, String> selectorLabels,
+                           final Map<String, String> labels) {
+            final Pod pod = new Pod();
+            final ObjectMeta meta = new ObjectMeta();
+            meta.setName(podName);
+            meta.setLabels(labels);
+            meta.setCreationTimestamp("1");
+            meta.setNamespace("default");
+            final PodSpec spec = new PodSpec();
+            spec.setSchedulerName(Scheduler.SCHEDULER_NAME);
+            spec.setPriority(0);
+            spec.setNodeSelector(selectorLabels);
+
+            final Container container = new Container();
+            container.setName("pause");
+
+            final ResourceRequirements resourceRequirements = new ResourceRequirements();
+            resourceRequirements.setRequests(Collections.emptyMap());
+            container.setResources(resourceRequirements);
+            spec.getContainers().add(container);
+
+            final Affinity affinity = new Affinity();
+            final NodeAffinity nodeAffinity = new NodeAffinity();
+            affinity.setNodeAffinity(nodeAffinity);
+            spec.setAffinity(affinity);
+            final PodStatus status = new PodStatus();
+            status.setPhase(phase);
+            pod.setMetadata(meta);
+            pod.setSpec(spec);
+            pod.setStatus(status);
+            return pod;
+        }
+    }
+
+    @Benchmark
+    public void testBatchUpdate(final BenchmarkState state) {
+        final IntStream stream = useParallelStream ? IntStream.range(0, numPods).parallel()
+                                                   : IntStream.range(0, numPods);
+        final List<PodInfoRecord> records = stream
+            .mapToObj(i -> {
+                    try (final DSLContext conn = state.dbConnectionPool.getConnectionToDb()) {
+                        final PodInfoRecord podInfoRecord = conn.selectFrom(Tables.POD_INFO)
+                                .where(Tables.POD_INFO.POD_NAME.eq("pod-" + i))
+                                .fetchOne();
+                        podInfoRecord.setNodeName("node-1");
+                        return podInfoRecord;
+                    }
+                }
+            ).collect(Collectors.toList());
+        try (final DSLContext conn = state.dbConnectionPool.getConnectionToDb()) {
+            final int[] execute = conn.batchUpdate(records).execute();
+            for (int i = 0; i < numPods; i++) {
+                if (execute[i] == 0) {
+                    throw new RuntimeException();
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void testBatch(final BenchmarkState state) {
+        final IntStream stream = useParallelStream ? IntStream.range(0, numPods).parallel()
+                : IntStream.range(0, numPods);
+        final List<UpdateConditionStep<PodInfoRecord>> records = stream
+            .mapToObj(i -> {
+                try (final DSLContext conn = state.dbConnectionPool.getConnectionToDb()) {
+                        return conn.update(Tables.POD_INFO)
+                                .set(Tables.POD_INFO.NODE_NAME, "node-1")
+                                .where(Tables.POD_INFO.POD_NAME.eq("pod-" + i));
+                    }
+                }
+            ).collect(Collectors.toList());
+        try (final DSLContext conn = state.dbConnectionPool.getConnectionToDb()) {
+            final int[] execute = conn.batch(records).execute();
+            for (int i = 0; i < numPods; i++) {
+                if (execute[i] == 0) {
+                    throw new RuntimeException();
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void testMultipleUpdates(final BenchmarkState state) {
+        final IntStream stream = useParallelStream ? IntStream.range(0, numPods).parallel()
+                                                   : IntStream.range(0, numPods);
+        final int[] execute = stream
+                .map(
+                    i -> {
+                        try (final DSLContext conn = state.dbConnectionPool.getConnectionToDb()) {
+                            return conn.update(Tables.POD_INFO)
+                                    .set(Tables.POD_INFO.NODE_NAME, "node-1")
+                                    .where(Tables.POD_INFO.POD_NAME.eq("pod-" + i))
+                                    .execute();
+                        }
+                    }
+                ).toArray();
+
+        for (int i = 0; i < numPods; i++) {
+            if (execute[i] == 0) {
+                throw new RuntimeException();
+            }
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/dcm/EndToEnd.java
+++ b/benchmarks/src/main/java/org/dcm/EndToEnd.java
@@ -82,7 +82,7 @@ public class EndToEnd {
                 node.getStatus().getCapacity().put("cpu", new Quantity("8"));
                 node.getStatus().getCapacity().put("memory", new Quantity("6000"));
                 node.getStatus().getCapacity().put("pods", new Quantity("110"));
-                nodeResourceEventHandler.onAdd(node);
+                nodeResourceEventHandler.onAddSync(node);
 
                 // Add one system pod per node
                 final String podName = "system-pod-" + nodeName;

--- a/build-common/src/main/resources/findbugs-exclude.xml
+++ b/build-common/src/main/resources/findbugs-exclude.xml
@@ -50,4 +50,9 @@
         <Class name="org.dcm.backend.OrToolsSolver$ExprToStrVisitor" />
         <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />
     </Match>
+
+    <!--  False positives due to try-with-resources pattern  -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
 </FindBugsFilter>

--- a/dcm/pom.xml
+++ b/dcm/pom.xml
@@ -25,6 +25,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>3.4.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
             <version>3.12.1</version>

--- a/dcm/pom.xml
+++ b/dcm/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.199</version>
+            <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dcm/pom.xml
+++ b/dcm/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.12.1</version>
+            <version>3.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq-meta</artifactId>
-            <version>3.12.1</version>
+            <version>3.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/dcm/src/main/java/org/dcm/Model.java
+++ b/dcm/src/main/java/org/dcm/Model.java
@@ -204,13 +204,10 @@ public class Model {
         final Meta dslMeta = dslContext.meta();
         final List<Table<?>> tables = new ArrayList<>();
         for (final Table<?> t : dslMeta.getTables()) {
-            // skip if table not on current schema
-            if (!t.getSchema().getName().equals(CURRENT_SCHEMA)) {
-                continue;
-            }
-            // If there are no constraints, access all tables. Else, only access the tables that are referenced
-            // by the constraints.
-            if (constraints.size() == 0 || accessedTableNames.contains(t.getName())) {
+            // If there are no constraints, access all tables in the CURR schema.
+            // Else, only access the tables that are referenced by the constraints.
+            if ((constraints.size() == 0 && t.getSchema().getName().equals(CURRENT_SCHEMA))
+                    || accessedTableNames.contains(t.getName())) {
                 tables.add(t);
 
                 // Also add tables referenced by foreign keys.

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -453,9 +453,10 @@ public class Ops {
             throw new RuntimeException("Empty domain for capacity constraint " + demands + " " + capacities);
         }
 
+        final Domain intervalRange = Domain.fromFlatIntervals(new long[] {domainT.min() + 1, domainT.max() + 1});
         for (int i = 0; i < numTasks; i++) {
             model.addLinearExpressionInDomain(taskToNodeAssignment[i], domainT);
-            final IntVar intervalEnd = model.newIntVar(domainT.min() + 1, domainT.max() + 1, "");
+            final IntVar intervalEnd = model.newIntVarFromDomain(intervalRange, "");
 
             // interval with start as taskToNodeAssignment and size of 1
             tasksIntervals[i] = model.newIntervalVar(taskToNodeAssignment[i],

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -16,9 +16,12 @@ import com.google.ortools.sat.Literal;
 import com.google.ortools.util.Domain;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Ops {
     private final CpModel model;
@@ -59,6 +62,10 @@ public class Ops {
     public void increasing(final List<IntVar> data) {
         for (int i = 0; i < data.size() - 1; i++) {
             model.addLessOrEqual(data.get(i), data.get(i + 1));
+
+            final IntVar bool = model.newBoolVar("");
+            model.addLessThan(data.get(i), data.get(i + 1)).onlyEnforceIf(bool); // soft constraint to maximize
+            model.maximize(LinearExpr.term(bool, 100));
         }
     }
 
@@ -107,7 +114,6 @@ public class Ops {
         model.addDivisionEquality(ret, left, model.newConstant(right));
         return ret;
     }
-
 
     public IntVar plus(final int left, final IntVar right) {
         return plus(model.newConstant(left), right);
@@ -427,6 +433,7 @@ public class Ops {
 
     public void capacityConstraint(final List<IntVar> varsToAssign, final List<String> domain,
                                    final List<List<Integer>> demands, final List<List<Integer>> capacities) {
+        final int scale = 1000;
         // Create the variables.
         capacities.forEach(
                 vec -> Preconditions.checkArgument(domain.size() == vec.size())
@@ -474,32 +481,79 @@ public class Ops {
         for (int i = 0; i < numResources; i++) {
             final List<Integer> demand = new ArrayList<>(demands.get(i));
             final int maxCapacity = maxCapacities.get(i);
-            for (final int value: nodeCapacities.get(i)) {
+            for (final int value : nodeCapacities.get(i)) {
                 demand.add(maxCapacity - value);
             }
             updatedDemands.add(demand);
         }
         updatedDemands.forEach(
-            vec -> Preconditions.checkArgument(vec.size() == (numTasks + capacities.get(0).size()))
+                vec -> Preconditions.checkArgument(vec.size() == (numTasks + capacities.get(0).size()))
         );
 
-        final List<int[]> taskDemands =
-                updatedDemands.stream().map(vec -> vec.stream().mapToInt(Integer::intValue).toArray())
-                        .collect(Collectors.toList());
+        // Scale demands by max-capacities. This normalizes all resource capacities/demands into the same range (0-100)
+        final List<int[]> taskDemands = new ArrayList<>(maxCapacities.size());
+        for (int i = 0; i < maxCapacities.size(); i++) {
+            final int capacity = maxCapacities.get(i);
+            final int[] scaledDemands = updatedDemands.get(i)
+                    .stream().mapToInt(e -> ((e * scale) / capacity))
+                    .toArray();
+            taskDemands.add(scaledDemands);
+        }
 
         // 2. Capacity constraints
         for (int i = 0; i < numResources; i++) {
-            model.addCumulative(tasksIntervals, taskDemands.get(i), model.newConstant(maxCapacities.get(i)));
+            model.addCumulative(tasksIntervals, taskDemands.get(i), model.newConstant(scale));
         }
 
         // Cumulative score
-        final IntVar[] maximumOfEachResource = new IntVar[numResources];
+        final IntVar[] maximumLoads = new IntVar[maxCapacities.size()];
         for (int i = 0; i < numResources; i++) {
-            final IntVar max = model.newIntVar(0, Integer.MAX_VALUE, "");
+            final IntVar max = model.newIntVar(0, scale, "");
             model.addCumulative(tasksIntervals, taskDemands.get(i), max);
-            maximumOfEachResource[i] = max;
+            maximumLoads[i] = max;
         }
+        model.minimize(LinearExpr.sum(maximumLoads));
 
-        model.minimize(LinearExpr.sum(maximumOfEachResource));   // minimize max score
+        // Prefer less loaded nodes
+        final int[] nodeIdToLoad = new int[domainArr.length];
+        for (int node = 0; node < domainArr.length; node++) {
+            int incidentLoadOnNode = 0;
+            for (int task = 0; task < numTasks; task++) {
+                for (int resource = 0; resource < numResources; resource++) {
+                    incidentLoadOnNode +=
+                            (capacities.get(resource).get(node) - (taskDemands.get(resource)[task] * 100))
+                                    / capacities.get(resource).get(node);
+                }
+            }
+            nodeIdToLoad[node] = incidentLoadOnNode;
+        }
+        final long[] domainSortedByLoad = IntStream.range(0, domainArr.length)
+                .boxed()
+                .sorted(Comparator.comparingInt(idx -> -nodeIdToLoad[idx]))
+                .mapToLong(idx -> domainArr[idx])
+                .toArray();
+        final int maxNumBuckets = 10;
+        final int bucketSize = Math.max(domainSortedByLoad.length / maxNumBuckets, 1);
+
+        Preconditions.checkArgument(domainSortedByLoad.length == domain.size());
+        long nodesConsidered = 0;
+
+        final List<IntVar> bools = new ArrayList<>();
+        for (int i = 0; i < domainSortedByLoad.length; i += bucketSize) {
+            final long[] subArray = Arrays.copyOfRange(domainSortedByLoad, i, i + bucketSize);
+            for (int task = 0; task < numTasks; task++) {
+                final IntVar boolVar = model.newBoolVar("");
+                model.addLinearExpressionInDomain(taskToNodeAssignment[task], Domain.fromValues(subArray))
+                        .onlyEnforceIf(boolVar);
+                bools.add(boolVar);
+            }
+            nodesConsidered += subArray.length;
+            if (nodesConsidered >= (taskToNodeAssignment.length * 2)) {
+                break;
+            }
+        }
+        final IntVar enforcement = model.newBoolVar("");
+        model.addBoolOr(bools.toArray(new IntVar[0])).onlyEnforceIf(enforcement);;
+        model.maximize(enforcement);
     }
 }

--- a/dcm/src/main/java/org/dcm/backend/Ops.java
+++ b/dcm/src/main/java/org/dcm/backend/Ops.java
@@ -442,6 +442,9 @@ public class Ops {
 
         final long[] domainArr = domain.stream().mapToLong(encoder::toLong).toArray();
         final Domain domainT = Domain.fromValues(domainArr);
+        if (domainArr.length == 0) {
+            throw new RuntimeException("Empty domain for capacity constraint " + demands + " " + capacities);
+        }
 
         for (int i = 0; i < numTasks; i++) {
             model.addLinearExpressionInDomain(taskToNodeAssignment[i], domainT);

--- a/dcm/src/test/java/org/dcm/backend/OpsTests.java
+++ b/dcm/src/test/java/org/dcm/backend/OpsTests.java
@@ -97,7 +97,7 @@ public class OpsTests {
         ops.increasing(entries);
         final CpSolver solver = new CpSolver();
         final CpSolverStatus solve = solver.solve(model);
-        assertEquals(CpSolverStatus.FEASIBLE, solve);
+        assertEquals(CpSolverStatus.OPTIMAL, solve);
 
         for (int i = 0; i < entries.size() - 1; i++) {
             assertTrue(solver.value(entries.get(i)) <= solver.value(entries.get(i + 1)));

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.199</version>
+            <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
 

--- a/k8s-scheduler/pom.xml
+++ b/k8s-scheduler/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq-meta-extensions</artifactId>
-            <version>3.12.1</version>
+            <version>3.13.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -127,7 +127,7 @@
             <plugin>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen-maven</artifactId>
-                <version>3.12.1</version>
+                <version>3.13.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/k8s-scheduler/pom.xml
+++ b/k8s-scheduler/pom.xml
@@ -35,16 +35,6 @@
             <version>4.9.0</version>
         </dependency>
         <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-            <version>2.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>io.reactivex.rxjava3</groupId>
-            <artifactId>rxjava</artifactId>
-            <version>3.0.0-RC3</version>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>4.1.0-rc3</version>
@@ -58,11 +48,6 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.davidmoten</groupId>
-            <artifactId>rxjava2-extras</artifactId>
-            <version>0.1.36</version>
         </dependency>
     </dependencies>
 

--- a/k8s-scheduler/src/main/java/org/dcm/DBConnectionPool.java
+++ b/k8s-scheduler/src/main/java/org/dcm/DBConnectionPool.java
@@ -39,7 +39,7 @@ class DBConnectionPool {
         this.databaseName = UUID.randomUUID().toString();
         setupDb();
         final HikariConfig config = new HikariConfig();
-        config.setJdbcUrl(String.format("jdbc:h2:mem:%s;", databaseName));
+        config.setJdbcUrl(String.format("jdbc:h2:mem:%s;LOG=0;UNDO_LOG=0", databaseName));
         config.addDataSourceProperty("cachePrepStmts", "true");
         config.addDataSourceProperty("prepStmtCacheSize", "250");
         config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
@@ -58,7 +58,7 @@ class DBConnectionPool {
         try (final BufferedReader tables = new BufferedReader(new InputStreamReader(resourceAsStream,
                 StandardCharsets.UTF_8))) {
             // Create a fresh database
-            final String connectionURL = String.format("jdbc:h2:mem:%s;create=true", databaseName);
+            final String connectionURL = String.format("jdbc:h2:mem:%s;create=true;LOG=0", databaseName);
             final Connection conn = DriverManager.getConnection(connectionURL, properties);
             final DSLContext using = using(conn, SQLDialect.H2);
             final String schemaAsString = tables.lines()

--- a/k8s-scheduler/src/main/java/org/dcm/DBConnectionPool.java
+++ b/k8s-scheduler/src/main/java/org/dcm/DBConnectionPool.java
@@ -12,6 +12,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
+import org.jooq.conf.Settings;
 
 import javax.sql.DataSource;
 import java.io.BufferedReader;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 import static org.jooq.impl.DSL.using;
 
 class DBConnectionPool {
+    private static final Settings JOOQ_SETTING = new Settings().withExecuteLogging(false);
     private final String databaseName;
     private final DataSource ds;
 
@@ -77,6 +79,6 @@ class DBConnectionPool {
      */
     @VisibleForTesting
     DSLContext getConnectionToDb() {
-        return using(ds, SQLDialect.H2);
+        return using(ds, SQLDialect.H2, JOOQ_SETTING);
     }
 }

--- a/k8s-scheduler/src/main/java/org/dcm/DBConnectionPool.java
+++ b/k8s-scheduler/src/main/java/org/dcm/DBConnectionPool.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package org.dcm;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+
+import javax.sql.DataSource;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.jooq.impl.DSL.using;
+
+class DBConnectionPool {
+    private final String databaseName;
+    private final DataSource ds;
+
+    DBConnectionPool() {
+        this.databaseName = UUID.randomUUID().toString();
+        setupDb();
+        final HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(String.format("jdbc:h2:mem:%s;", databaseName));
+        config.addDataSourceProperty("cachePrepStmts", "true");
+        config.addDataSourceProperty("prepStmtCacheSize", "250");
+        config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        config.addDataSourceProperty("maximumPoolSize", "20");
+        this.ds = new HikariDataSource(config);
+    }
+
+    /**
+     * Sets up a private, in-memory database.
+     */
+    private void setupDb() {
+
+        final Properties properties = new Properties();
+        properties.setProperty("foreign_keys", "true");
+        final InputStream resourceAsStream = Scheduler.class.getResourceAsStream("/scheduler_tables.sql");
+        try (final BufferedReader tables = new BufferedReader(new InputStreamReader(resourceAsStream,
+                StandardCharsets.UTF_8))) {
+            // Create a fresh database
+            final String connectionURL = String.format("jdbc:h2:mem:%s;create=true", databaseName);
+            final Connection conn = DriverManager.getConnection(connectionURL, properties);
+            final DSLContext using = using(conn, SQLDialect.H2);
+            final String schemaAsString = tables.lines()
+                    .filter(line -> !line.startsWith("--")) // remove SQL comments
+                    .collect(Collectors.joining("\n"));
+            final List<String> semiColonSeparated = Splitter.on(";")
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .splitToList(schemaAsString);
+            semiColonSeparated.forEach(using::execute);
+        } catch (final SQLException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets up a private, in-memory database.
+     */
+    @VisibleForTesting
+    DSLContext getConnectionToDb() {
+        return using(ds, SQLDialect.H2);
+    }
+}

--- a/k8s-scheduler/src/main/java/org/dcm/EmulatedPodToNodeBinder.java
+++ b/k8s-scheduler/src/main/java/org/dcm/EmulatedPodToNodeBinder.java
@@ -9,14 +9,19 @@ package org.dcm;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import org.dcm.k8s.generated.Tables;
+import org.dcm.k8s.generated.tables.records.PodInfoRecord;
 import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.Update;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
 
 
 /**
@@ -25,29 +30,20 @@ import java.util.concurrent.Executors;
 public class EmulatedPodToNodeBinder implements IPodToNodeBinder {
     private static final Logger LOG = LoggerFactory.getLogger(EmulatedPodToNodeBinder.class);
     private final DBConnectionPool dbConnectionPool;
-    private final ExecutorService executorService = Executors.newScheduledThreadPool(5);
     private final Map<String, SettableFuture<Boolean>> waitForPodBinding = new HashMap<>();
 
     EmulatedPodToNodeBinder(final DBConnectionPool dbConnectionPool) {
         this.dbConnectionPool = dbConnectionPool;
     }
 
-    @Override
-    public void bindOne(final String namespace, final String podName, final String nodeName) {
+    public Update<PodInfoRecord> bindOne(final String namespace, final String podName, final String nodeName) {
         LOG.info("Binding {}/pod:{} to node:{}", namespace, podName, nodeName);
 
         // Mimic a binding notification
-        executorService.execute(() -> {
-            try (final DSLContext conn = dbConnectionPool.getConnectionToDb()) {
-                conn.update(Tables.POD_INFO)
-                        .set(Tables.POD_INFO.STATUS, "Running")
-                        .where(Tables.POD_INFO.POD_NAME.eq(podName))
-                        .execute();
-                }
-            }
-        );
-        if (waitForPodBinding.containsKey(podName)) {
-            waitForPodBinding.get(podName).set(true);
+        try (final DSLContext conn = dbConnectionPool.getConnectionToDb()) {
+            return conn.update(Tables.POD_INFO)
+                    .set(Tables.POD_INFO.STATUS, "Running")
+                    .where(Tables.POD_INFO.POD_NAME.eq(podName));
         }
     }
 
@@ -55,5 +51,30 @@ public class EmulatedPodToNodeBinder implements IPodToNodeBinder {
         final SettableFuture<Boolean> settableFuture = SettableFuture.create();
         waitForPodBinding.put(podname, settableFuture);
         return settableFuture;
+    }
+
+    @Override
+    public void bindManyAsnc(final Result<? extends Record> records) {
+        ForkJoinPool.commonPool().execute(
+            () -> {
+                final List<Update<PodInfoRecord>> updates = records.stream().map(record -> {
+                            final String podName = record.get(Tables.PODS_TO_ASSIGN.POD_NAME);
+                            final String namespace = record.get(Tables.PODS_TO_ASSIGN.NAMESPACE);
+                            final String nodeName = record.get(Tables.PODS_TO_ASSIGN.CONTROLLABLE__NODE_NAME);
+                            LOG.info("Attempting to bind {}:{} to {} ", namespace, podName, nodeName);
+                            return bindOne(namespace, podName, nodeName);
+                        }
+                ).collect(Collectors.toList());
+                try (final DSLContext conn = dbConnectionPool.getConnectionToDb()) {
+                    conn.batch(updates).execute();
+                }
+                records.forEach(record -> {
+                    final String podName = record.get(Tables.PODS_TO_ASSIGN.POD_NAME);
+                    if (waitForPodBinding.containsKey(podName)) {
+                        waitForPodBinding.get(podName).set(true);
+                    }
+                });
+            }
+        );
     }
 }

--- a/k8s-scheduler/src/main/java/org/dcm/IPodToNodeBinder.java
+++ b/k8s-scheduler/src/main/java/org/dcm/IPodToNodeBinder.java
@@ -7,9 +7,12 @@
 package org.dcm;
 
 
+import org.jooq.Record;
+import org.jooq.Result;
+
 /**
  * An interface used by the scheduler to bind pods to nodes, either in a real cluster or in an emulated environment
  */
 public interface IPodToNodeBinder {
-    void bindOne(final String namespace, final String podName, final String nodeName);
+    void bindManyAsnc(final Result<? extends Record> records);
 }

--- a/k8s-scheduler/src/main/java/org/dcm/KubernetesBinder.java
+++ b/k8s-scheduler/src/main/java/org/dcm/KubernetesBinder.java
@@ -6,10 +6,19 @@
 
 package org.dcm;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.fabric8.kubernetes.api.model.Binding;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectReference;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.dcm.k8s.generated.Tables;
+import org.jooq.Record;
+import org.jooq.Result;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadFactory;
 
 
 /**
@@ -17,12 +26,14 @@ import io.fabric8.kubernetes.client.KubernetesClient;
  */
 class KubernetesBinder implements IPodToNodeBinder {
     private final KubernetesClient client;
+    private final ThreadFactory namedThreadFactory =
+            new ThreadFactoryBuilder().setNameFormat("bind-thread-%d").build();
+    private final ExecutorService service = Executors.newFixedThreadPool(10, namedThreadFactory);
 
     KubernetesBinder(final KubernetesClient client) {
         this.client = client;
     }
 
-    @Override
     public void bindOne(final String namespace, final String podName, final String nodeName) {
         final Binding binding = new Binding();
         final ObjectReference target = new ObjectReference();
@@ -34,5 +45,18 @@ class KubernetesBinder implements IPodToNodeBinder {
         binding.setTarget(target);
         binding.setMetadata(meta);
         client.bindings().inNamespace(namespace).create(binding);
+    }
+
+    @Override
+    public void bindManyAsnc(final Result<? extends Record> records) {
+        ForkJoinPool.commonPool().execute(() -> records.forEach(
+                r -> service.execute(() -> {
+                    final String podName = r.get(Tables.PODS_TO_ASSIGN.POD_NAME);
+                    final String namespace = r.get(Tables.PODS_TO_ASSIGN.NAMESPACE);
+                    final String nodeName = r.get(Tables.PODS_TO_ASSIGN.CONTROLLABLE__NODE_NAME);
+                    bindOne(namespace, podName, nodeName);
+                }
+            )
+        ));
     }
 }

--- a/k8s-scheduler/src/main/java/org/dcm/KubernetesStateSync.java
+++ b/k8s-scheduler/src/main/java/org/dcm/KubernetesStateSync.java
@@ -16,7 +16,6 @@ import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.reactivex.Flowable;
 import io.reactivex.processors.PublishProcessor;
-import org.jooq.DSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +27,11 @@ class KubernetesStateSync {
         this.sharedInformerFactory = client.informers();
     }
 
-    Flowable<PodEvent> setupInformersAndPodEventStream(final DSLContext conn) {
+    Flowable<PodEvent> setupInformersAndPodEventStream(final DBConnectionPool dbConnectionPool) {
 
         final SharedIndexInformer<Node> nodeSharedIndexInformer = sharedInformerFactory
                 .sharedIndexInformerFor(Node.class, NodeList.class, 30000);
-        nodeSharedIndexInformer.addEventHandler(new NodeResourceEventHandler(conn));
+        nodeSharedIndexInformer.addEventHandler(new NodeResourceEventHandler(dbConnectionPool));
 
         // Pod informer
         final SharedIndexInformer<Pod> podInformer = sharedInformerFactory

--- a/k8s-scheduler/src/main/java/org/dcm/NodeResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/NodeResourceEventHandler.java
@@ -45,7 +45,7 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
 
     NodeResourceEventHandler(final DBConnectionPool dbConnectionPool) {
         this.dbConnectionPool = dbConnectionPool;
-        this.service = Executors.newCachedThreadPool();
+        this.service = Executors.newFixedThreadPool(10);
     }
 
     NodeResourceEventHandler(final DBConnectionPool dbConnectionPool, final ExecutorService service) {

--- a/k8s-scheduler/src/main/java/org/dcm/NodeResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/NodeResourceEventHandler.java
@@ -12,18 +12,25 @@ import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeCondition;
 import io.fabric8.kubernetes.api.model.NodeStatus;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.Taint;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import org.dcm.k8s.generated.Tables;
+import org.dcm.k8s.generated.tables.NodeInfo;
+import org.dcm.k8s.generated.tables.records.NodeImagesRecord;
 import org.dcm.k8s.generated.tables.records.NodeInfoRecord;
+import org.dcm.k8s.generated.tables.records.NodeLabelsRecord;
+import org.dcm.k8s.generated.tables.records.NodeTaintsRecord;
 import org.jooq.DSLContext;
+import org.jooq.Insert;
+import org.jooq.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 /**
@@ -41,12 +48,14 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
     @Override
     public void onAdd(final Node node) {
         final long now = System.nanoTime();
-        final DSLContext conn = dbConnectionPool.getConnectionToDb();
-        final NodeInfoRecord nodeInfoRecord = conn.newRecord(Tables.NODE_INFO);
-        updateNodeRecord(nodeInfoRecord, node);
-        addNodeLabels(conn, node);
-        addNodeTaints(conn, node);
-        addNodeImages(conn, node);
+        try (final DSLContext conn = dbConnectionPool.getConnectionToDb()) {
+            final List<Query> queries = new ArrayList<>();
+            queries.add(updateNodeRecord(node, conn));
+            queries.addAll(addNodeLabels(conn, node));
+            queries.addAll(addNodeTaints(conn, node));
+            queries.addAll(addNodeImages(conn, node));
+            conn.batch(queries).execute();
+        }
         LOG.info("{} node added in {}ms", node.getMetadata().getName(), (System.nanoTime() - now));
     }
 
@@ -54,39 +63,39 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
     public void onUpdate(final Node oldNode, final Node newNode) {
         final long now = System.nanoTime();
         final boolean hasChanged = hasChanged(oldNode, newNode);
-        final DSLContext conn = dbConnectionPool.getConnectionToDb();
-        if (hasChanged) {
-            // TODO: relax this assumption by setting up update cascades for node_info.name FK references
-            Preconditions.checkArgument(newNode.getMetadata().getName().equals(oldNode.getMetadata().getName()));
-            final NodeInfoRecord nodeInfoRecord = conn.selectFrom(Tables.NODE_INFO)
-                    .where(Tables.NODE_INFO.NAME.eq(oldNode.getMetadata().getName()))
-                    .fetchOne();
-            updateNodeRecord(nodeInfoRecord, newNode);
+        try (final DSLContext conn = dbConnectionPool.getConnectionToDb()) {
+            final List<Query> queries = new ArrayList<>();
+            if (hasChanged) {
+                // TODO: relax this assumption by setting up update cascades for node_info.name FK references
+                Preconditions.checkArgument(newNode.getMetadata().getName().equals(oldNode.getMetadata().getName()));
+                queries.add(updateNodeRecord(newNode, conn));
 
-            if (!Optional.ofNullable(oldNode.getSpec().getTaints())
-                    .equals(Optional.ofNullable(newNode.getSpec().getTaints()))) {
-                conn.deleteFrom(Tables.NODE_TAINTS)
-                        .where(Tables.NODE_TAINTS.NODE_NAME
-                                .eq(oldNode.getMetadata().getName()))
-                        .execute();
-                addNodeTaints(conn, newNode);
+                if (!Optional.ofNullable(oldNode.getSpec().getTaints())
+                        .equals(Optional.ofNullable(newNode.getSpec().getTaints()))) {
+                    queries.add(
+                        conn.deleteFrom(Tables.NODE_TAINTS)
+                                .where(Tables.NODE_TAINTS.NODE_NAME
+                                        .eq(oldNode.getMetadata().getName()))
+                    );
+                    queries.addAll(addNodeTaints(conn, newNode));
+                }
+                if (!Optional.ofNullable(oldNode.getMetadata().getLabels())
+                        .equals(Optional.ofNullable(newNode.getMetadata().getLabels()))) {
+                    queries.add(conn.deleteFrom(Tables.NODE_LABELS)
+                            .where(Tables.NODE_LABELS.NODE_NAME
+                                    .eq(oldNode.getMetadata().getName())));
+                    queries.addAll(addNodeTaints(conn, newNode));
+                }
+                if (!Optional.ofNullable(oldNode.getStatus().getImages())
+                        .equals(Optional.ofNullable(newNode.getStatus().getImages()))) {
+                    queries.add(
+                        conn.deleteFrom(Tables.NODE_IMAGES)
+                                .where(Tables.NODE_IMAGES.NODE_NAME
+                                        .eq(oldNode.getMetadata().getName())));
+                    queries.addAll(addNodeTaints(conn, newNode));
+                }
             }
-            if (!Optional.ofNullable(oldNode.getMetadata().getLabels())
-                    .equals(Optional.ofNullable(newNode.getMetadata().getLabels()))) {
-                conn.deleteFrom(Tables.NODE_LABELS)
-                        .where(Tables.NODE_LABELS.NODE_NAME
-                                .eq(oldNode.getMetadata().getName()))
-                        .execute();
-                addNodeTaints(conn, newNode);
-            }
-            if (!Optional.ofNullable(oldNode.getStatus().getImages())
-                    .equals(Optional.ofNullable(newNode.getStatus().getImages()))) {
-                conn.deleteFrom(Tables.NODE_IMAGES)
-                        .where(Tables.NODE_IMAGES.NODE_NAME
-                                .eq(oldNode.getMetadata().getName()))
-                        .execute();
-                addNodeTaints(conn, newNode);
-            }
+            conn.batch(queries).execute();
         }
         LOG.info("{} => {} node {} in {}ns", oldNode.getMetadata().getName(), newNode.getMetadata().getName(),
                 hasChanged ? "updated" : "not updated", (System.nanoTime() - now));
@@ -100,7 +109,7 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
         LOG.info("{} node deleted in {}ms", node.getMetadata().getName(), (System.nanoTime() - now));
     }
 
-    private void updateNodeRecord(final NodeInfoRecord nodeInfoRecord, final Node node) {
+    private Insert<NodeInfoRecord> updateNodeRecord(final Node node, final DSLContext conn) {
         final NodeStatus status = node.getStatus();
         final Map<String, Quantity> capacity = status.getCapacity();
         final Map<String, Quantity> allocatable = status.getAllocatable();
@@ -149,33 +158,73 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
         final long ephemeralStorageAllocatable = (long) Utils.convertUnit(allocatable.get("ephemeral-storage"),
                                                                          "ephemeral-storage");
         final long podsAllocatable = Long.parseLong(allocatable.get("pods").getAmount());
-        nodeInfoRecord.setName(node.getMetadata().getName());
-        nodeInfoRecord.setUnschedulable(getUnschedulable);
-        nodeInfoRecord.setOutOfDisk(outOfDisk);
-        nodeInfoRecord.setMemoryPressure(memoryPressure);
-        nodeInfoRecord.setDiskPressure(diskPressure);
-        nodeInfoRecord.setPidPressure(pidPressure);
-        nodeInfoRecord.setReady(ready);
-        nodeInfoRecord.setNetworkUnavailable(networkUnavailable);
-        nodeInfoRecord.setCpuCapacity(cpuCapacity);
-        nodeInfoRecord.setMemoryCapacity(memoryCapacity);
-        nodeInfoRecord.setEphemeralStorageCapacity(ephemeralStorageCapacity);
-        nodeInfoRecord.setPodsCapacity(podCapacity);
-        nodeInfoRecord.setCpuAllocatable(cpuAllocatable);
-        nodeInfoRecord.setMemoryAllocatable(memoryAllocatable);
-        nodeInfoRecord.setEphemeralStorageAllocatable(ephemeralStorageAllocatable);
-        nodeInfoRecord.setPodsAllocatable(podsAllocatable);
 
-        // These entries are updated by us on every pod arrival/departure
-        nodeInfoRecord.setCpuAllocated(zeroIfNull(nodeInfoRecord.getCpuAllocated()));
-        nodeInfoRecord.setMemoryAllocated(zeroIfNull(nodeInfoRecord.getMemoryAllocated()));
-        nodeInfoRecord.setEphemeralStorageAllocated(zeroIfNull(nodeInfoRecord.getEphemeralStorageAllocated()));
-        nodeInfoRecord.setPodsAllocated(zeroIfNull(nodeInfoRecord.getPodsAllocated()));
-        nodeInfoRecord.store();
-    }
+        final NodeInfo n = Tables.NODE_INFO;
+        return conn.insertInto(Tables.NODE_INFO,
+                n.NAME,
+                n.UNSCHEDULABLE,
+                n.OUT_OF_DISK,
+                n.MEMORY_PRESSURE,
+                n.DISK_PRESSURE,
+                n.PID_PRESSURE,
+                n.READY,
+                n.NETWORK_UNAVAILABLE,
+                n.CPU_CAPACITY,
+                n.MEMORY_CAPACITY,
+                n.EPHEMERAL_STORAGE_CAPACITY,
+                n.PODS_CAPACITY,
+                n.CPU_ALLOCATABLE,
+                n.MEMORY_ALLOCATABLE,
+                n.EPHEMERAL_STORAGE_ALLOCATABLE,
+                n.PODS_ALLOCATABLE,
+                n.CPU_ALLOCATED,
+                n.MEMORY_ALLOCATED,
+                n.EPHEMERAL_STORAGE_ALLOCATED,
+                n.PODS_ALLOCATED)
+            .values(node.getMetadata().getName(),
+                    getUnschedulable,
+                    outOfDisk,
+                    memoryPressure,
+                    diskPressure,
+                    pidPressure,
+                    ready,
+                    networkUnavailable,
+                    cpuCapacity,
+                    memoryCapacity,
+                    ephemeralStorageCapacity,
+                    podCapacity,
+                    cpuAllocatable,
+                    memoryAllocatable,
+                    ephemeralStorageAllocatable,
+                    podsAllocatable,
+                    0L, // cpu allocated default
+                    0L, // mem allocated default
+                    0L, // ephemeral storage allocated default
+                    0L // pods allocated default
+            )
+            .onDuplicateKeyUpdate()
+            .set(n.NAME, node.getMetadata().getName())
+            .set(n.UNSCHEDULABLE, getUnschedulable)
+            .set(n.OUT_OF_DISK, outOfDisk)
+            .set(n.MEMORY_PRESSURE, memoryPressure)
+            .set(n.DISK_PRESSURE, diskPressure)
+            .set(n.PID_PRESSURE, pidPressure)
+            .set(n.READY, ready)
+            .set(n.NETWORK_UNAVAILABLE, networkUnavailable)
+            .set(n.CPU_CAPACITY, cpuCapacity)
+            .set(n.MEMORY_CAPACITY, memoryCapacity)
+            .set(n.EPHEMERAL_STORAGE_CAPACITY, ephemeralStorageCapacity)
+            .set(n.PODS_CAPACITY, podCapacity)
+            .set(n.CPU_ALLOCATABLE, cpuAllocatable)
+            .set(n.MEMORY_ALLOCATABLE, memoryAllocatable)
+            .set(n.EPHEMERAL_STORAGE_ALLOCATABLE, ephemeralStorageAllocatable)
+            .set(n.PODS_ALLOCATABLE, podsAllocatable)
 
-    private long zeroIfNull(@Nullable final Long value) {
-        return value == null ? 0 : value;
+            // These entries are updated by us on every pod arrival/departure
+            .set(n.CPU_ALLOCATED, n.CPU_ALLOCATED)
+            .set(n.MEMORY_ALLOCATED, n.MEMORY_ALLOCATED)
+            .set(n.EPHEMERAL_STORAGE_ALLOCATED, n.EPHEMERAL_STORAGE_ALLOCATED)
+            .set(n.PODS_ALLOCATED, n.PODS_ALLOCATED);
     }
 
     private boolean hasChanged(final Node oldNode, final Node newNode) {
@@ -209,36 +258,38 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
         LOG.info("Node {} deleted", node.getMetadata().getName());
     }
 
-    private void addNodeLabels(final DSLContext conn, final Node node) {
+    private List<Insert<NodeLabelsRecord>> addNodeLabels(final DSLContext conn, final Node node) {
         final Map<String, String> labels = node.getMetadata().getLabels();
-        labels.forEach(
-                (k, v) -> conn.insertInto(Tables.NODE_LABELS)
-                        .values(node.getMetadata().getName(), k, v)
-                        .execute()
-        );
+        return labels.entrySet().stream().map(
+                (label) -> conn.insertInto(Tables.NODE_LABELS)
+                        .values(node.getMetadata().getName(), label.getKey(), label.getValue())
+        ).collect(Collectors.toList());
     }
 
-    private void addNodeTaints(final DSLContext conn, final Node node) {
+    private List<Insert<NodeTaintsRecord>> addNodeTaints(final DSLContext conn, final Node node) {
         if (node.getSpec().getTaints() == null) {
-            return;
+            return Collections.emptyList();
         }
-
-        for (final Taint taint: node.getSpec().getTaints()) {
-            conn.insertInto(Tables.NODE_TAINTS)
-                    .values(node.getMetadata().getName(),
-                            taint.getKey(),
-                            taint.getValue(),
-                            taint.getEffect()).execute();
-        }
+        return node.getSpec().getTaints().stream().map(taint ->
+                    conn.insertInto(Tables.NODE_TAINTS)
+                            .values(node.getMetadata().getName(),
+                                    taint.getKey(),
+                                    taint.getValue(),
+                                    taint.getEffect())
+                ).collect(Collectors.toList());
     }
 
-    private void addNodeImages(final DSLContext conn, final Node node) {
+    private List<Insert<NodeImagesRecord>> addNodeImages(final DSLContext conn, final Node node) {
+        final List<Insert<NodeImagesRecord>> inserts = new ArrayList<>();
         for (final ContainerImage image: node.getStatus().getImages()) {
             for (final String imageName: image.getNames()) {
                 final int imageSizeInMb = (int) (((float) image.getSizeBytes()) / 1024 / 1024);
-                conn.insertInto(Tables.NODE_IMAGES)
-                    .values(node.getMetadata().getName(), imageName, imageSizeInMb).execute();
+                inserts.add(
+                    conn.insertInto(Tables.NODE_IMAGES)
+                        .values(node.getMetadata().getName(), imageName, imageSizeInMb)
+                );
             }
         }
+        return inserts;
     }
 }

--- a/k8s-scheduler/src/main/java/org/dcm/PodEventsToDatabase.java
+++ b/k8s-scheduler/src/main/java/org/dcm/PodEventsToDatabase.java
@@ -85,7 +85,7 @@ class PodEventsToDatabase {
     }
 
     private void addPod(final Pod pod) {
-        LOG.info("Adding pod {}", pod.getMetadata().getName());
+        LOG.trace("Adding pod {}", pod.getMetadata().getName());
         try (final DSLContext conn = dbConnectionPool.getConnectionToDb()) {
             final List<Query> inserts = new ArrayList<>();
             inserts.addAll(updatePodRecord(pod, conn));
@@ -100,7 +100,7 @@ class PodEventsToDatabase {
     }
 
     private void deletePod(final Pod pod) {
-        LOG.info("Deleting pod {}", pod.getMetadata().getName());
+        LOG.trace("Deleting pod {}", pod.getMetadata().getName());
         // The assumption here is that all foreign key references to pod_info.pod_name will be deleted using
         // a delete cascade
 

--- a/k8s-scheduler/src/main/java/org/dcm/PodResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/PodResourceEventHandler.java
@@ -6,7 +6,6 @@
 
 package org.dcm;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.reactivex.processors.PublishProcessor;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 
 /**
@@ -26,13 +24,18 @@ import java.util.concurrent.ThreadFactory;
 class PodResourceEventHandler implements ResourceEventHandler<Pod> {
     private static final Logger LOG = LoggerFactory.getLogger(PodResourceEventHandler.class);
     private final PublishProcessor<PodEvent> flowable;
-    private final ThreadFactory namedThreadFactory =
-            new ThreadFactoryBuilder().setNameFormat("flowable-thread-%d").build();
-    private final ExecutorService service = Executors.newFixedThreadPool(10, namedThreadFactory);
+    private final ExecutorService service;
 
     PodResourceEventHandler(final PublishProcessor<PodEvent> flowable) {
         this.flowable = flowable;
+        this.service = Executors.newCachedThreadPool();
     }
+
+    PodResourceEventHandler(final PublishProcessor<PodEvent> flowable, final ExecutorService service) {
+        this.flowable = flowable;
+        this.service = service;
+    }
+
 
     public void onAddSync(final Pod pod) {
         LOG.info("{} pod add received", pod.getMetadata().getName());

--- a/k8s-scheduler/src/main/java/org/dcm/PodResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/PodResourceEventHandler.java
@@ -28,7 +28,7 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
 
     PodResourceEventHandler(final PublishProcessor<PodEvent> flowable) {
         this.flowable = flowable;
-        this.service = Executors.newCachedThreadPool();
+        this.service = Executors.newFixedThreadPool(10);
     }
 
     PodResourceEventHandler(final PublishProcessor<PodEvent> flowable, final ExecutorService service) {
@@ -38,7 +38,7 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
 
 
     public void onAddSync(final Pod pod) {
-        LOG.info("{} pod add received", pod.getMetadata().getName());
+        LOG.debug("{} pod add received", pod.getMetadata().getName());
         flowable.onNext(new PodEvent(PodEvent.Action.ADDED, pod)); // might be better to add pods in a batch
     }
 

--- a/k8s-scheduler/src/main/java/org/dcm/PodResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/PodResourceEventHandler.java
@@ -38,7 +38,7 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
 
 
     public void onAddSync(final Pod pod) {
-        LOG.debug("{} pod add received", pod.getMetadata().getName());
+        LOG.trace("{} pod add received", pod.getMetadata().getName());
         podEventNotification.accept(new PodEvent(PodEvent.Action.ADDED, pod)); // might be better to add pods in a batch
 
     }
@@ -47,13 +47,13 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
         final String oldPodScheduler = oldPod.getSpec().getSchedulerName();
         final String newPodScheduler = oldPod.getSpec().getSchedulerName();
         assert oldPodScheduler.equals(newPodScheduler);
-        LOG.debug("{} => {} pod update received", oldPod.getMetadata().getName(), newPod.getMetadata().getName());
+        LOG.trace("{} => {} pod update received", oldPod.getMetadata().getName(), newPod.getMetadata().getName());
         podEventNotification.accept(new PodEvent(PodEvent.Action.UPDATED, newPod));
     }
 
     public void onDeleteSync(final Pod pod, final boolean deletedFinalStateUnknown) {
         final long now = System.nanoTime();
-        LOG.debug("{} pod deleted ({}) in {}ns!", pod.getMetadata().getName(), deletedFinalStateUnknown,
+        LOG.trace("{} pod deleted ({}) in {}ns!", pod.getMetadata().getName(), deletedFinalStateUnknown,
                                                   (System.nanoTime() - now));
         podEventNotification.accept(new PodEvent(PodEvent.Action.DELETED, pod));
     }

--- a/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
@@ -10,7 +10,6 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.github.davidmoten.rx2.flowable.Transformers;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -101,8 +100,8 @@ public final class Scheduler {
                     && podEvent.getPod().getSpec().getSchedulerName().equals(
                     Scheduler.SCHEDULER_NAME)
             )
-            .compose(Transformers.buffer(batchCount, batchTimeMs, TimeUnit.MILLISECONDS))
-//            .buffer(batchTimeMs, TimeUnit.MILLISECONDS, batchCount)
+//            .compose(Transformers.buffer(batchCount, batchTimeMs, TimeUnit.MILLISECONDS))
+            .buffer(batchTimeMs, TimeUnit.MILLISECONDS, batchCount)
             .filter(podEvents -> !podEvents.isEmpty())
             .observeOn(Schedulers.from(Executors.newSingleThreadExecutor(namedThreadFactory)))
             .subscribe(

--- a/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
@@ -205,6 +205,8 @@ public final class Scheduler {
                 "Scheduler batch interval");
         options.addRequiredOption("m", "solver", true,
                 "Solver to use: MNZ-CHUFFED, ORTOOLS");
+        options.addRequiredOption("t", "num-threads", true,
+                "Number of threads to use for or-tools");
         final CommandLineParser parser = new DefaultParser();
         final CommandLine cmd = parser.parse(options, args);
 
@@ -213,7 +215,7 @@ public final class Scheduler {
                 Policies.getDefaultPolicies(),
                 cmd.getOptionValue("solver"),
                 Boolean.parseBoolean(cmd.getOptionValue("debug-mode")),
-                Integer.parseInt(cmd.getOptionValue("numThreads")));
+                Integer.parseInt(cmd.getOptionValue("num-threads")));
 
         final KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         LOG.info("Running a scheduler that connects to a Kubernetes cluster on {}",

--- a/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/org/dcm/Scheduler.java
@@ -115,29 +115,6 @@ public final class Scheduler {
                     }
                 }
         );
-//        subscription = eventStream
-//            .map(podEventsToDatabase::handle)
-//            .filter(podEvent -> podEvent.getAction().equals(PodEvent.Action.ADDED)
-//                    && podEvent.getPod().getStatus().getPhase().equals("Pending")
-//                    && podEvent.getPod().getSpec().getNodeName() == null
-//                    && podEvent.getPod().getSpec().getSchedulerName().equals(
-//                    Scheduler.SCHEDULER_NAME)
-//            )
-////            .compose(Transformers.buffer(batchCount, batchTimeMs, TimeUnit.MILLISECONDS))
-//            .buffer(batchTimeMs, TimeUnit.MILLISECONDS, batchCount)
-//            .filter(podEvents -> !podEvents.isEmpty())
-//            .observeOn(Schedulers.from(Executors.newSingleThreadExecutor(namedThreadFactory)))
-//            .subscribe(
-//                podEvents -> {
-//                    podsPerSchedulingEvent.update(podEvents.size());
-//                    LOG.info("Received the following {} events: {}", podEvents.size(), podEvents);
-//                    scheduleAllPendingPods(binder);
-//                },
-//                e -> {
-//                    LOG.error("Received exception. Dumping DB state to /tmp/", e);
-//                    DebugUtils.dbDump(dbConnectionPool.getConnectionToDb());
-//                }
-//            );
     }
 
     @SuppressWarnings("unchecked")

--- a/k8s-scheduler/src/main/resources/log4j2.xml
+++ b/k8s-scheduler/src/main/resources/log4j2.xml
@@ -14,7 +14,7 @@
     <Loggers>
         <Logger name="org.jooq.Constants" additivity="false" level="OFF">
         </Logger>
-        <Logger name="org.dcm.PodResourceEventHandler" additivity="false" level="debug">
+        <Logger name="org.dcm.PodResourceEventHandler" additivity="false" level="info">
             <AppenderRef ref="console" />
         </Logger>
         <Logger name="org.dcm.EmulatedPodDeployer" additivity="false" level="info">

--- a/k8s-scheduler/src/main/resources/log4j2.xml
+++ b/k8s-scheduler/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
   ~ SPDX-License-Identifier: BSD-2
   -->
 
-<Configuration status="DEBUG">
+<Configuration status="INFO">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%highlight{%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n}"/>
@@ -13,6 +13,8 @@
     </Appenders>
     <Loggers>
         <Logger name="org.jooq.Constants" additivity="false" level="OFF">
+        </Logger>
+        <Logger name="org.jooq.tools.LoggerListener" additivity="false" level="off">
         </Logger>
         <Logger name="org.dcm.PodResourceEventHandler" additivity="false" level="info">
             <AppenderRef ref="console" />

--- a/k8s-scheduler/src/main/resources/scheduler_tables.sql
+++ b/k8s-scheduler/src/main/resources/scheduler_tables.sql
@@ -222,8 +222,7 @@ select
   equivalence_class,
   qos_class
 from pod_info
-where status = 'Pending' and node_name is null and schedulerName = 'dcm-scheduler'
-order by creation_timestamp;
+where status = 'Pending' and node_name is null and schedulerName = 'dcm-scheduler';
 
 -- This view is updated dynamically to change the limit. This
 -- pattern is required because there is no clean way to enforce

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -55,7 +55,7 @@ class EmulatedClusterTest {
             node.getStatus().getCapacity().put("cpu", new Quantity("8"));
             node.getStatus().getCapacity().put("memory", new Quantity("6000"));
             node.getStatus().getCapacity().put("pods", new Quantity("110"));
-            nodeResourceEventHandler.onAdd(node);
+            nodeResourceEventHandler.onAddSync(node);
 
             // Add one system pod per node
             final String podName = "system-pod-" + nodeName;

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.reactivex.processors.PublishProcessor;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -39,17 +38,17 @@ class EmulatedClusterTest {
     @Test
     @Disabled
     public void runTraceLocally() throws Exception {
-        final DSLContext conn = Scheduler.setupDb();
+        final DBConnectionPool dbConnectionPool = new DBConnectionPool();
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
         final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
         final int numNodes = 1000;
 
         // Add all nodes
-        final NodeResourceEventHandler nodeResourceEventHandler = new NodeResourceEventHandler(conn);
+        final NodeResourceEventHandler nodeResourceEventHandler = new NodeResourceEventHandler(dbConnectionPool);
 
         final List<String> policies = Policies.getDefaultPolicies();
-        final Scheduler scheduler = new Scheduler(conn, policies, "ORTOOLS", true, 4);
-        scheduler.startScheduler(emitter, new EmulatedPodToNodeBinder(conn), 100, 500);
+        final Scheduler scheduler = new Scheduler(dbConnectionPool, policies, "ORTOOLS", true, 4);
+        scheduler.startScheduler(emitter, new EmulatedPodToNodeBinder(dbConnectionPool), 100, 500);
         for (int i = 0; i < numNodes; i++) {
             final String nodeName = "n" + i;
             final Node node = addNode(nodeName, Collections.emptyMap(), Collections.emptyList());

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -57,7 +57,7 @@ class EmulatedClusterTest {
 
         final List<String> policies = Policies.getDefaultPolicies();
         final Scheduler scheduler = new Scheduler(dbConnectionPool, policies, "ORTOOLS", true, 4);
-        scheduler.startScheduler(emitter, new EmulatedPodToNodeBinder(dbConnectionPool), 100, 500);
+        scheduler.startScheduler(emitter, new EmulatedPodToNodeBinder(dbConnectionPool), 100, 50);
         for (int i = 0; i < numNodes; i++) {
             final String nodeName = "n" + i;
             final Node node = addNode(nodeName, Collections.emptyMap(), Collections.emptyList());

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
@@ -7,7 +7,6 @@
 package org.dcm;
 
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.RateLimiter;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -29,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class EmulatedPodDeployer implements IPodDeployer {
     private static final Logger LOG = LoggerFactory.getLogger(EmulatedPodDeployer.class);
-    private final RateLimiter limiter = RateLimiter.create(10);
     private final PodResourceEventHandler resourceEventHandler;
     private final String namespace;
     private final Map<String, List<Pod>> pods = new ConcurrentHashMap<>();
@@ -79,7 +77,6 @@ public class EmulatedPodDeployer implements IPodDeployer {
                 pod.setSpec(spec);
                 pod.setStatus(status);
                 pods.computeIfAbsent(deploymentName, (k) -> new ArrayList<>()).add(pod);
-                limiter.acquire();
                 resourceEventHandler.onAdd(pod);
             }
         }

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
@@ -7,6 +7,7 @@
 package org.dcm;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.RateLimiter;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class EmulatedPodDeployer implements IPodDeployer {
     private static final Logger LOG = LoggerFactory.getLogger(EmulatedPodDeployer.class);
+    private final RateLimiter limiter = RateLimiter.create(10);
     private final PodResourceEventHandler resourceEventHandler;
     private final String namespace;
     private final Map<String, List<Pod>> pods = new ConcurrentHashMap<>();
@@ -77,6 +79,7 @@ public class EmulatedPodDeployer implements IPodDeployer {
                 pod.setSpec(spec);
                 pod.setStatus(status);
                 pods.computeIfAbsent(deploymentName, (k) -> new ArrayList<>()).add(pod);
+                limiter.acquire();
                 resourceEventHandler.onAdd(pod);
             }
         }

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedPodDeployer.java
@@ -57,9 +57,9 @@ public class EmulatedPodDeployer implements IPodDeployer {
         @Override
         public void run() {
             final String deploymentName = deployment.getMetadata().getName();
-            LOG.info("Creating deployment (name:{}, schedulerName:{}) at {}",
+            LOG.info("Creating deployment (name:{}, schedulerName:{}, replicas:{}) at {}",
                     deploymentName, deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
-                    System.currentTimeMillis());
+                    deployment.getSpec().getReplicas(), System.currentTimeMillis());
 
             for (int i = 0; i < deployment.getSpec().getReplicas(); i++) {
                 final Pod pod = new Pod();
@@ -77,7 +77,7 @@ public class EmulatedPodDeployer implements IPodDeployer {
                 pod.setSpec(spec);
                 pod.setStatus(status);
                 pods.computeIfAbsent(deploymentName, (k) -> new ArrayList<>()).add(pod);
-                resourceEventHandler.onAddSync(pod);
+                resourceEventHandler.onAdd(pod);
             }
         }
     }
@@ -91,9 +91,9 @@ public class EmulatedPodDeployer implements IPodDeployer {
 
         @Override
         public void run() {
-            LOG.info("Terminating deployment (name:{}, schedulerName:{}) at {}",
+            LOG.info("Terminating deployment (name:{}, schedulerName:{}, replicas:{}) at {}",
                 deployment.getMetadata().getName(), deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
-                System.currentTimeMillis());
+                deployment.getSpec().getReplicas(), System.currentTimeMillis());
             final List<Pod> podsList = pods.get(deployment.getMetadata().getName());
             Preconditions.checkNotNull(podsList);
             for (final Pod pod: podsList) {

--- a/k8s-scheduler/src/test/java/org/dcm/IPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/IPodDeployer.java
@@ -6,7 +6,9 @@
 
 package org.dcm;
 
-import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.Pod;
+
+import java.util.List;
 
 /**
  * An interface used by WorkloadGeneratorIT.runTrace() to create and delete pod deployments. It allows
@@ -14,7 +16,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
  */
 public interface IPodDeployer {
 
-    Runnable startDeployment(final Deployment deployment);
+    Runnable startDeployment(final List<Pod> deployment);
 
-    Runnable endDeployment(final Deployment deployment);
+    Runnable endDeployment(final List<Pod> deployment);
 }

--- a/k8s-scheduler/src/test/java/org/dcm/KubernetesPodDeployer.java
+++ b/k8s-scheduler/src/test/java/org/dcm/KubernetesPodDeployer.java
@@ -45,9 +45,10 @@ public class KubernetesPodDeployer implements IPodDeployer {
 
         @Override
         public void run() {
-            LOG.info("Creating deployment (name:{}, schedulerName:{}) with masterUrl {} at {}",
+            LOG.info("Creating deployment (name:{}, schedulerName:{}, replicas:{}) with masterUrl {} at {}",
                     deployment.getMetadata().getName(), deployment.getSpec().getTemplate().getSpec().getSchedulerName(),
-                    fabricClient.getConfiguration().getMasterUrl(), System.currentTimeMillis());
+                    deployment.getSpec().getReplicas(), fabricClient.getConfiguration().getMasterUrl(),
+                    System.currentTimeMillis());
             fabricClient.apps().deployments().inNamespace(namespace)
                     .create(this.deployment);
         }

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerIT.java
@@ -8,7 +8,6 @@ package org.dcm;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.reactivex.Flowable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -43,8 +42,8 @@ public class SchedulerIT extends ITBase {
         final Scheduler scheduler = new Scheduler(dbConnectionPool, Policies.getDefaultPolicies(), "ORTOOLS", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
-        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);
-        scheduler.startScheduler(eventStream, new KubernetesBinder(fabricClient), 50, 1000);
+        stateSync.setupInformersAndPodEventStream(dbConnectionPool, scheduler::handlePodEvent);
+        scheduler.startScheduler(new KubernetesBinder(fabricClient), 50, 1000);
         stateSync.startProcessingEvents();
 
         // Add a new one
@@ -73,8 +72,8 @@ public class SchedulerIT extends ITBase {
                                        "ORTOOLS", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
-        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);
-        scheduler.startScheduler(eventStream, new KubernetesBinder(fabricClient),  50, 1000);
+        stateSync.setupInformersAndPodEventStream(dbConnectionPool, scheduler::handlePodEvent);
+        scheduler.startScheduler(new KubernetesBinder(fabricClient),  50, 1000);
         stateSync.startProcessingEvents();
 
         // Add a new one
@@ -112,8 +111,8 @@ public class SchedulerIT extends ITBase {
         final Scheduler scheduler = new Scheduler(dbConnectionPool, Policies.getDefaultPolicies(), "ORTOOLS", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
-        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);
-        scheduler.startScheduler(eventStream, new KubernetesBinder(fabricClient), 50, 1000);
+        stateSync.setupInformersAndPodEventStream(dbConnectionPool, scheduler::handlePodEvent);
+        scheduler.startScheduler(new KubernetesBinder(fabricClient), 50, 1000);
         stateSync.startProcessingEvents();
 
         // Add a new one

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerIT.java
@@ -70,7 +70,7 @@ public class SchedulerIT extends ITBase {
     public void testAffinityAntiAffinity() throws Exception {
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
         final Scheduler scheduler = new Scheduler(dbConnectionPool, Policies.getDefaultPolicies(),
-                                       "MNZ-CHUFFED", true, 4);
+                                       "ORTOOLS", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
         final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerIT.java
@@ -9,7 +9,6 @@ package org.dcm;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.reactivex.Flowable;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -40,11 +39,11 @@ public class SchedulerIT extends ITBase {
     @Test()
     @Timeout(60 /* seconds */)
     public void testDeployments() throws Exception {
-        final DSLContext conn = Scheduler.setupDb();
-        final Scheduler scheduler = new Scheduler(conn, Policies.getDefaultPolicies(), "ORTOOLS", true, 4);
+        final DBConnectionPool dbConnectionPool = new DBConnectionPool();
+        final Scheduler scheduler = new Scheduler(dbConnectionPool, Policies.getDefaultPolicies(), "ORTOOLS", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
-        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(conn);
+        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);
         scheduler.startScheduler(eventStream, new KubernetesBinder(fabricClient), 50, 1000);
         stateSync.startProcessingEvents();
 
@@ -69,11 +68,12 @@ public class SchedulerIT extends ITBase {
     @Test()
     @Timeout(60 /* seconds */)
     public void testAffinityAntiAffinity() throws Exception {
-        final DSLContext conn = Scheduler.setupDb();
-        final Scheduler scheduler = new Scheduler(conn, Policies.getDefaultPolicies(), "MNZ-CHUFFED", true, 4);
+        final DBConnectionPool dbConnectionPool = new DBConnectionPool();
+        final Scheduler scheduler = new Scheduler(dbConnectionPool, Policies.getDefaultPolicies(),
+                                       "MNZ-CHUFFED", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
-        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(conn);
+        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);
         scheduler.startScheduler(eventStream, new KubernetesBinder(fabricClient),  50, 1000);
         stateSync.startProcessingEvents();
 
@@ -108,11 +108,11 @@ public class SchedulerIT extends ITBase {
     @Test()
     @Timeout(60 /* seconds */)
     public void testSmallTrace() throws Exception {
-        final DSLContext conn = Scheduler.setupDb();
-        final Scheduler scheduler = new Scheduler(conn, Policies.getDefaultPolicies(), "ORTOOLS", true, 4);
+        final DBConnectionPool dbConnectionPool = new DBConnectionPool();
+        final Scheduler scheduler = new Scheduler(dbConnectionPool, Policies.getDefaultPolicies(), "ORTOOLS", true, 4);
         final KubernetesStateSync stateSync = new KubernetesStateSync(fabricClient);
 
-        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(conn);
+        final Flowable<PodEvent> eventStream = stateSync.setupInformersAndPodEventStream(dbConnectionPool);
         scheduler.startScheduler(eventStream, new KubernetesBinder(fabricClient), 50, 1000);
         stateSync.startProcessingEvents();
 

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -1059,8 +1059,8 @@ public class SchedulerTest {
         final DSLContext conn = dbConnectionPool.getConnectionToDb();
         final List<String> policies = Policies.getDefaultPolicies();
         final NodeResourceEventHandler nodeResourceEventHandler = new NodeResourceEventHandler(dbConnectionPool);
-        final int numNodes = 500;
-        final int numPods = 100000;
+        final int numNodes = 50;
+        final int numPods = 102;
         conn.insertInto(Tables.BATCH_SIZE).values(numPods).execute();
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
         final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -204,7 +204,7 @@ public class SchedulerTest {
             final NodeCondition badCondition = new NodeCondition();
             badCondition.setStatus(status);
             badCondition.setType(type);
-            nodeResourceEventHandler.onAdd(addNode("n" + i, Collections.emptyMap(),
+            nodeResourceEventHandler.onAddSync(addNode("n" + i, Collections.emptyMap(),
                                            i == nodeToAssignTo ? Collections.emptyList() : List.of(badCondition)));
 
             // Add one system pod per node
@@ -288,7 +288,7 @@ public class SchedulerTest {
             else {
                 nodesWithoutLabels.add(nodeName);
             }
-            nodeResourceEventHandler.onAdd(addNode(nodeName, nodeLabels, Collections.emptyList()));
+            nodeResourceEventHandler.onAddSync(addNode(nodeName, nodeLabels, Collections.emptyList()));
 
             // Add one system pod per node
             final String podName = "system-pod-n" + i;
@@ -406,7 +406,7 @@ public class SchedulerTest {
                 nodeLabels.put("dummyKey2", "dummyValue2");
                 remainingNodes.add(nodeName);
             }
-            nodeResourceEventHandler.onAdd(addNode(nodeName, nodeLabels, Collections.emptyList()));
+            nodeResourceEventHandler.onAddSync(addNode(nodeName, nodeLabels, Collections.emptyList()));
 
             // Add one system pod per node
             final String podName = "system-pod-n" + i;
@@ -572,7 +572,7 @@ public class SchedulerTest {
         for (int i = 0; i < numNodes; i++) {
             final String nodeName = "n" + i;
             final Node node = addNode(nodeName, Collections.emptyMap(), Collections.emptyList());
-            nodeResourceEventHandler.onAdd(node);
+            nodeResourceEventHandler.onAddSync(node);
 
             // Add one system pod per node
             final String podName = "system-pod-n" + i;
@@ -793,7 +793,7 @@ public class SchedulerTest {
             node.getStatus().getCapacity().put("cpu",
                                                new Quantity(String.valueOf(nodeCpuCapacities.get(i))));
             node.getStatus().getCapacity().put("memory", new Quantity(String.valueOf(nodeMemoryCapacities.get(i))));
-            nodeResourceEventHandler.onAdd(node);
+            nodeResourceEventHandler.onAddSync(node);
 
             // Add one system pod per node
             final String podName = "system-pod-" + nodeName;
@@ -884,7 +884,7 @@ public class SchedulerTest {
             final String nodeName = "n" + i;
             final Node node = addNode(nodeName, Collections.emptyMap(), Collections.emptyList());
             node.getSpec().setTaints(taints.get(i));
-            nodeResourceEventHandler.onAdd(node);
+            nodeResourceEventHandler.onAddSync(node);
 
             // Add one system pod per node
             final String podName = "system-pod-n" + i;
@@ -1063,7 +1063,7 @@ public class SchedulerTest {
         emitter.map(eventHandler::handle).subscribe();
 
         for (int i = 0; i < numNodes; i++) {
-            nodeResourceEventHandler.onAdd(addNode("n" + i, Collections.emptyMap(),
+            nodeResourceEventHandler.onAddSync(addNode("n" + i, Collections.emptyMap(),
                                            Collections.emptyList()));
 
             // Add one system pod per node

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -760,7 +760,6 @@ public class SchedulerTest {
         assertEquals(cpuRequests.size(), memoryRequests.size());
         assertEquals(nodeCpuCapacities.size(), nodeMemoryCapacities.size());
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
-        final DSLContext conn = dbConnectionPool.getConnectionToDb();
         final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
         final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
@@ -809,14 +808,11 @@ public class SchedulerTest {
                                                     Policies.capacityConstraint(useHardConstraint, useSoftConstraint));
         final Scheduler scheduler = new Scheduler(dbConnectionPool, policies, "ORTOOLS", true, numThreads);
         if (feasible) {
-            System.out.println(conn.selectFrom(Tables.PODS_TO_ASSIGN).fetch());
-            System.out.println(conn.selectFrom(Tables.NODE_INFO).fetch());
             final Result<? extends Record> result = scheduler.runOneLoop();
             assertEquals(numPods, result.size());
             final List<String> nodes = result.stream()
                                             .map(e -> e.getValue("CONTROLLABLE__NODE_NAME", String.class))
                                             .collect(Collectors.toList());
-            System.out.println(nodes);
             assertTrue(assertOn.test(nodes));
         } else {
             assertThrows(ModelException.class, scheduler::runOneLoop);
@@ -1039,7 +1035,6 @@ public class SchedulerTest {
         final DSLContext conn = dbConnectionPool.getConnectionToDb();
         final List<String> policies = Policies.getDefaultPolicies();
         DebugUtils.dbLoad(conn);
-
         // All pod additions have completed
         final Scheduler scheduler = new Scheduler(dbConnectionPool, policies, "ORTOOLS", true, numThreads);
         for (int i = 0; i < 100; i++) {

--- a/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/SchedulerTest.java
@@ -34,7 +34,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Taint;
 import io.fabric8.kubernetes.api.model.Toleration;
-import io.reactivex.processors.PublishProcessor;
 import org.dcm.k8s.generated.Tables;
 import org.dcm.k8s.generated.tables.records.PodInfoRecord;
 import org.jooq.DSLContext;
@@ -193,10 +192,8 @@ public class SchedulerTest {
         final int numNodes = 5;
         final int numPods = 10;
         conn.insertInto(Tables.BATCH_SIZE).values(numPods).execute();
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
 
         // We pick a random node from [0, numNodes) to assign all pods to.
         final int nodeToAssignTo = ThreadLocalRandom.current().nextInt(numNodes);
@@ -244,10 +241,9 @@ public class SchedulerTest {
                                     final Set<String> nodesToMatch, final Set<String> nodesPartialMatch) {
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
         final DSLContext conn = dbConnectionPool.getConnectionToDb();
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
+
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
 
         final int numPods = 10;
         final int numNodes = 10;
@@ -358,10 +354,9 @@ public class SchedulerTest {
                                       final boolean shouldBeAffineToRemainingNodes) {
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
         final DSLContext conn = dbConnectionPool.getConnectionToDb();
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
+
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
 
         final int numPods = 10;
         final int numNodes = 100;
@@ -527,10 +522,9 @@ public class SchedulerTest {
         final int numPodsToModify = 3;
         final int numNodes = 3;
 
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
+
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
 
         final List<String> allPods = IntStream.range(0, numPods)
                 .mapToObj(i -> "p" + i)
@@ -760,10 +754,9 @@ public class SchedulerTest {
         assertEquals(cpuRequests.size(), memoryRequests.size());
         assertEquals(nodeCpuCapacities.size(), nodeMemoryCapacities.size());
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
+
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
         final int numPods = cpuRequests.size();
         final int numNodes = nodeCpuCapacities.size();
 
@@ -859,10 +852,9 @@ public class SchedulerTest {
                                          final List<List<Taint>> taints, final Predicate<List<String>> assertOn,
                                          final boolean feasible) {
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
+
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
 
         final int numPods = tolerations.size();
         final int numNodes = taints.size();
@@ -1057,10 +1049,9 @@ public class SchedulerTest {
         final int numNodes = 50;
         final int numPods = 102;
         conn.insertInto(Tables.BATCH_SIZE).values(numPods).execute();
-        final PublishProcessor<PodEvent> emitter = PublishProcessor.create();
-        final PodResourceEventHandler handler = new PodResourceEventHandler(emitter);
+
         final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
-        emitter.map(eventHandler::handle).subscribe();
+        final PodResourceEventHandler handler = new PodResourceEventHandler(eventHandler::handle);
 
         for (int i = 0; i < numNodes; i++) {
             nodeResourceEventHandler.onAddSync(addNode("n" + i, Collections.emptyMap(),

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -258,7 +258,8 @@ class WorkloadGeneratorIT extends ITBase {
                  " will happen at {}s. Sleeping for {}s before teardown.", totalPods, maxStart,
                 maxEnd, maxEnd);
 
-        final List<Object> objects = Futures.successfulAsList(deletions).get();
+        final List<Object> objects = Futures.successfulAsList(deletions).get(maxEnd + 100, TimeUnit.SECONDS);
+
         assert objects.size() != 0;
     }
 

--- a/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/org/dcm/WorkloadGeneratorIT.java
@@ -210,7 +210,7 @@ class WorkloadGeneratorIT extends ITBase {
                 final int end = Integer.parseInt(parts[3]) / timeScaleDown;
                 final float cpu = Float.parseFloat(parts[4].replace(">", "")) / cpuScaleDown;
                 final float mem = Float.parseFloat(parts[5].replace(">", "")) / memScaleDown;
-                final int vmCount = Integer.parseInt(parts[6].replace(">", ""));
+                final int vmCount = Math.max(20, Integer.parseInt(parts[6].replace(">", "")));
 
                 // generate a deployment's details based on cpu, mem requirements
                 final Deployment deployment = getDeployment(client, schedulerName, cpu, mem, vmCount, taskCount);

--- a/k8s-scheduler/src/test/resources/pod-only.yml
+++ b/k8s-scheduler/src/test/resources/pod-only.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cache
+  labels:
+    app: store
+spec:
+  schedulerName: default-scheduler
+  containers:
+    - name: cache
+      image: k8s.gcr.io/pause

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.12.2</version>
+                <version>4.0.0</version>
                 <dependencies>
                     <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
                     <dependency>
@@ -128,7 +128,7 @@
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs</artifactId>
-                        <version>3.1.12</version>
+                        <version>4.0.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
                              -XepAllErrorsAsWarnings
                              -Xep:Finally:OFF
                              -XepExcludedPaths:(.*/annotations/org/dcm/generated/.*|.*/org/dcm/k8s/generated/.*)
-                             -implicit
                         </arg>
+                        <arg>-implicit:class</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>


### PR DESCRIPTION
This PR represents a combination of several changes as part of a performance improvement overhaul:

* Migrate away from RxJava flowable as a mechanism to notify the scheduling thread of new pod arrivals. We instead use a threadpool to write updates into the database before writing a notification into a blocking queue. A single scheduler thread waits on the notification queue and aggressively makes scheduling decisions until `pods_to_assign` is empty.

* Make inserts/updates into the database using `create.batch()` to minimize the number of JDBC round trips. This study was informed by JMH benchmarks which have also been added.

* Use a database connection pool instead of a single shared connection among all objects that use the DB. This is required to take advantage of multi-threading, otherwise, all objects contend for the per-connection locks.

* Improvements to the cumulative constraint wherein we introduce half-reified constraints and an objective function to bias assignments to least loaded nodes.

* Simplify workload replay: instead of creating deployments, we directly create pods. This overcomes problems we've had for a while now with the K8s API (even in large clusters) rate limiting pod creations and (especially) deletions.

* Also bumps JOOQ and H2 versions.

