### PR TITLE
Rewriting Affinity Queries

### DIFF
--- a/dcm/src/main/java/org/dcm/Model.java
+++ b/dcm/src/main/java/org/dcm/Model.java
@@ -419,8 +419,9 @@ public class Model {
             final long select = System.nanoTime();
             irTable.updateValues(recentData);
             final long updateValues = System.nanoTime();
-            LOG.info("updateDataFields for table {} took {}ns to fetch from DB, and {}ns to reflect in IRTables",
-                     table.getName(), (select - start), (System.nanoTime() - updateValues));
+            LOG.info("updateDataFields for table {} took {} ns to fetch {} rows from DB, " +
+                            "and {} ns to reflect in IRTables",
+                     table.getName(), (select - start), recentData.size(), (System.nanoTime() - updateValues));
         }
         compiler.updateData(irContext, backend);
         LOG.info("compiler.updateData() took {}ns to complete", (System.nanoTime() - updateData));

--- a/k8s-scheduler/src/main/resources/scheduler_tables.sql
+++ b/k8s-scheduler/src/main/resources/scheduler_tables.sql
@@ -116,7 +116,8 @@ create table pod_labels
   pod_name varchar(100) not null,
   label_key varchar(100) not null,
   label_value varchar(36) not null,
-  foreign key(pod_name) references pod_info(pod_name) on delete cascade
+  foreign key(pod_name) references pod_info(pod_name) on delete cascade,
+  primary key(pod_name, label_key, label_value)
 );
 
 -- Tracks the set of labels per node
@@ -280,74 +281,134 @@ create index pod_node_selector_labels_fk_idx on pod_node_selector_labels (pod_na
 create index node_labels_idx on node_labels (label_key, label_value);
 
 -- Inter pod affinity
+create view inter_pod_affinity_matches_inner_exists as
+select
+  pods_to_assign.pod_name as pods_to_assign_pod_name,
+  pod_labels.pod_name as pod_labels_pod_name,
+  pod_affinity_match_expressions.label_selector,
+  pod_affinity_match_expressions.topology_key,
+  pod_affinity_match_expressions.label_operator,
+  pod_affinity_match_expressions.num_match_expressions,
+  pod_affinity_match_expressions.match_expression,
+  pod_info.node_name
+from
+  pods_to_assign
+  join pod_affinity_match_expressions on pods_to_assign.pod_name = pod_affinity_match_expressions.pod_name
+  join pod_labels on (
+    pod_affinity_match_expressions.label_operator = 'Exists'
+    and pod_affinity_match_expressions.label_key = pod_labels.label_key
+  )
+  join pod_info on pod_labels.pod_name = pod_info.pod_name
+  where pods_to_assign.has_pod_affinity_requirements = true;
+
+create view inter_pod_affinity_matches_inner_in as
+select
+  pods_to_assign.pod_name as pods_to_assign_pod_name,
+  pod_labels.pod_name as pod_labels_pod_name,
+  pod_affinity_match_expressions.label_selector,
+  pod_affinity_match_expressions.topology_key,
+  pod_affinity_match_expressions.label_operator,
+  pod_affinity_match_expressions.num_match_expressions,
+  pod_affinity_match_expressions.match_expression,
+  pod_info.node_name
+from
+  pods_to_assign
+  join pod_affinity_match_expressions on pods_to_assign.pod_name = pod_affinity_match_expressions.pod_name
+  join pod_labels on (
+    pod_affinity_match_expressions.label_operator = 'In'
+    and pod_affinity_match_expressions.label_key = pod_labels.label_key
+    and pod_labels.label_value in (unnest(pod_affinity_match_expressions.label_value))
+  )
+  join pod_info on pod_labels.pod_name = pod_info.pod_name
+  where pods_to_assign.has_pod_affinity_requirements = true;
+
 create view inter_pod_affinity_matches_inner as
-select pods_to_assign.pod_name as pod_name,
-       pod_labels.pod_name as matches,
-       pod_info.node_name as node_name
-from pods_to_assign
-join pod_affinity_match_expressions
-     on pods_to_assign.pod_name = pod_affinity_match_expressions.pod_name
-join pod_labels
-        on (pod_affinity_match_expressions.label_operator = 'In'
-            and pod_affinity_match_expressions.label_key = pod_labels.label_key
-            and  pod_labels.label_value in (unnest(pod_affinity_match_expressions.label_value)))
-        or (pod_affinity_match_expressions.label_operator = 'Exists'
-            and pod_affinity_match_expressions.label_key = pod_labels.label_key)
-        or (pod_affinity_match_expressions.label_operator = 'NotIn')
-        or (pod_affinity_match_expressions.label_operator = 'DoesNotExist')
-join pod_info
-        on pod_labels.pod_name = pod_info.pod_name
-where pods_to_assign.has_pod_affinity_requirements = true
-group by pods_to_assign.pod_name,  pod_labels.pod_name, pod_affinity_match_expressions.label_selector,
-         pod_affinity_match_expressions.topology_key, pod_affinity_match_expressions.label_operator,
-         pod_affinity_match_expressions.num_match_expressions, pod_info.node_name
-having case pod_affinity_match_expressions.label_operator
-             when 'NotIn'
-                  then not(any(pod_affinity_match_expressions.label_key = pod_labels.label_key
-                               and pod_labels.label_value in (unnest(pod_affinity_match_expressions.label_value))))
-             when 'DoesNotExist'
-                  then not(any(pod_affinity_match_expressions.label_key = pod_labels.label_key))
-             else count(distinct match_expression) = pod_affinity_match_expressions.num_match_expressions
-       end;
+select
+  pods_to_assign_pod_name as pod_name,
+  pod_labels_pod_name as matches,
+  node_name as node_name
+from
+  ((select * from inter_pod_affinity_matches_inner_in)
+    union
+      (select * from inter_pod_affinity_matches_inner_exists))
+group by
+  pods_to_assign_pod_name,
+  pod_labels_pod_name,
+  label_selector,
+  topology_key,
+  label_operator,
+  num_match_expressions,
+  node_name
+having
+  count(distinct match_expression) = num_match_expressions;
 
 create view inter_pod_affinity_matches as
 select *, count(*) over (partition by pod_name) as num_matches from inter_pod_affinity_matches_inner;
 
 create index pod_affinity_match_expressions_idx on pod_affinity_match_expressions (pod_name);
+create index pod_anti_affinity_match_expressions_idx on pod_anti_affinity_match_expressions (pod_name);
 create index pod_labels_idx on pod_labels (label_key, label_value);
 
+create view inter_pod_anti_affinity_matches_inner_exists as
+select
+  pods_to_assign.pod_name as pods_to_assign_pod_name,
+  pod_labels.pod_name as pod_labels_pod_name,
+  pod_anti_affinity_match_expressions.label_selector,
+  pod_anti_affinity_match_expressions.topology_key,
+  pod_anti_affinity_match_expressions.label_operator,
+  pod_anti_affinity_match_expressions.num_match_expressions,
+  pod_anti_affinity_match_expressions.match_expression,
+  pod_info.node_name
+from
+  pods_to_assign
+  join pod_anti_affinity_match_expressions on pods_to_assign.pod_name = pod_anti_affinity_match_expressions.pod_name
+  join pod_labels on (
+    pod_anti_affinity_match_expressions.label_operator = 'Exists'
+    and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
+  )
+  join pod_info on pod_labels.pod_name = pod_info.pod_name
+  where pods_to_assign.has_pod_anti_affinity_requirements = true;
 
--- Inter pod anti-affinity
--- TODO: the having clause could be simplified: if even a single term matches, we can preclude a node
+create view inter_pod_anti_affinity_matches_inner_in as
+select
+  pods_to_assign.pod_name as pods_to_assign_pod_name,
+  pod_labels.pod_name as pod_labels_pod_name,
+  pod_anti_affinity_match_expressions.label_selector,
+  pod_anti_affinity_match_expressions.topology_key,
+  pod_anti_affinity_match_expressions.label_operator,
+  pod_anti_affinity_match_expressions.num_match_expressions,
+  pod_anti_affinity_match_expressions.match_expression,
+  pod_info.node_name
+from
+  pods_to_assign
+  join pod_anti_affinity_match_expressions on pods_to_assign.pod_name = pod_anti_affinity_match_expressions.pod_name
+  join pod_labels on (
+    pod_anti_affinity_match_expressions.label_operator = 'In'
+    and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
+    and pod_labels.label_value in (unnest(pod_anti_affinity_match_expressions.label_value))
+  )
+  join pod_info on pod_labels.pod_name = pod_info.pod_name
+  where pods_to_assign.has_pod_anti_affinity_requirements = true;
+
 create view inter_pod_anti_affinity_matches_inner as
-select pods_to_assign.pod_name as pod_name,
-       pod_labels.pod_name as matches,
-       pod_info.node_name as node_name
-from pods_to_assign
-join pod_anti_affinity_match_expressions
-     on pods_to_assign.pod_name = pod_anti_affinity_match_expressions.pod_name
-join pod_labels
-        on (pod_anti_affinity_match_expressions.label_operator = 'In'
-            and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
-            and pod_labels.label_value in (unnest(pod_anti_affinity_match_expressions.label_value)))
-        or (pod_anti_affinity_match_expressions.label_operator = 'Exists'
-            and pod_anti_affinity_match_expressions.label_key = pod_labels.label_key)
-        or (pod_anti_affinity_match_expressions.label_operator = 'NotIn')
-        or (pod_anti_affinity_match_expressions.label_operator = 'DoesNotExist')
-join pod_info
-        on pod_labels.pod_name = pod_info.pod_name
-where pods_to_assign.has_pod_anti_affinity_requirements = true
-group by pods_to_assign.pod_name,  pod_labels.pod_name, pod_anti_affinity_match_expressions.label_selector,
-         pod_anti_affinity_match_expressions.topology_key, pod_anti_affinity_match_expressions.label_operator,
-         pod_anti_affinity_match_expressions.num_match_expressions, pod_info.node_name
-having case pod_anti_affinity_match_expressions.label_operator
-             when 'NotIn'
-                  then not(any(pod_anti_affinity_match_expressions.label_key = pod_labels.label_key
-                               and pod_labels.label_value in (unnest(pod_anti_affinity_match_expressions.label_value))))
-             when 'DoesNotExist'
-                  then not(any(pod_anti_affinity_match_expressions.label_key = pod_labels.label_key))
-             else count(distinct match_expression) = pod_anti_affinity_match_expressions.num_match_expressions
-       end;
+select
+  pods_to_assign_pod_name as pod_name,
+  pod_labels_pod_name as matches,
+  node_name as node_name
+from
+  ((select * from inter_pod_anti_affinity_matches_inner_in)
+    union
+      (select * from inter_pod_anti_affinity_matches_inner_exists))
+group by
+  pods_to_assign_pod_name,
+  pod_labels_pod_name,
+  label_selector,
+  topology_key,
+  label_operator,
+  num_match_expressions,
+  node_name
+having
+  count(distinct match_expression) = num_match_expressions;
 
 create view inter_pod_anti_affinity_matches as
 select *, count(*) over (partition by pod_name) as num_matches from inter_pod_anti_affinity_matches_inner;

--- a/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
+++ b/k8s-scheduler/src/test/java/org/dcm/EmulatedClusterTest.java
@@ -44,7 +44,8 @@ class EmulatedClusterTest {
     private static final Logger LOG = LoggerFactory.getLogger(EmulatedClusterTest.class);
 
     public void runTraceLocally(final int numNodes, final String traceFileName, final int cpuScaleDown,
-                                final int memScaleDown, final int timeScaleDown, final int startTimeCutOff)
+                                final int memScaleDown, final int timeScaleDown, final int startTimeCutOff,
+                                final int affinityRequirementsProportion)
             throws Exception {
         final DBConnectionPool dbConnectionPool = new DBConnectionPool();
 
@@ -86,8 +87,8 @@ class EmulatedClusterTest {
         final WorkloadGeneratorIT replay = new WorkloadGeneratorIT();
         final IPodDeployer deployer = new EmulatedPodDeployer(handler, "default");
         final DefaultKubernetesClient client = new DefaultKubernetesClient();
-        replay.runTrace(client, traceFileName, deployer, "dcm-scheduler",
-                        cpuScaleDown, memScaleDown, timeScaleDown, startTimeCutOff);
+        replay.runTrace(client, traceFileName, deployer, "dcm-scheduler", cpuScaleDown,
+                memScaleDown, timeScaleDown, startTimeCutOff, affinityRequirementsProportion);
     }
 
     private static Node addNode(final String nodeName, final Map<String, String> labels,
@@ -164,6 +165,11 @@ class EmulatedClusterTest {
                         "Factor by which to scale down arrival rate for pods");
         options.addRequiredOption("s", "startTimeCutOff", true,
                         "N, where we replay first N seconds of trace");
+        options.addOption("p", "proportion", true,
+                "P, from 0 to 100, indicating the proportion of pods that have affinity requirements");
+        options.addOption("d", "deploymentAffinity", true,
+                "D, 1 if pods in a deployment should be affine to each other," +
+                        " 2 if pods across deployments should be affine to each other");
         final CommandLineParser parser = new DefaultParser();
         final CommandLine cmd = parser.parse(options, args);
         final int numNodes = Integer.parseInt(cmd.getOptionValue("numNodes"));
@@ -172,11 +178,14 @@ class EmulatedClusterTest {
         final int memScaleDown = Integer.parseInt(cmd.getOptionValue("memScaleDown"));
         final int timeScaleDown = Integer.parseInt(cmd.getOptionValue("timeScaleDown"));
         final int startTimeCutOff = Integer.parseInt(cmd.getOptionValue("startTimeCutOff"));
-        LOG.info("Running experiment with parameters: numNodes:{}, traceFile:{}, cpuScaleDown:{}, " +
-                    "memScaleDown:{}, timeScaleDown:{}, startTimeCutOff:{}", numNodes, traceFile, cpuScaleDown,
-                memScaleDown, timeScaleDown, startTimeCutOff);
+        final int affinityRequirementsProportion = Integer.parseInt(cmd.hasOption("proportion") ?
+                cmd.getOptionValue("proportion") : "0");
+        LOG.info("Running experiment with parameters: numNodes: {}, traceFile: {}, cpuScaleDown: {}, " +
+                    "memScaleDown: {}, timeScaleDown: {}, startTimeCutOff: {}, proportion: {}",
+                numNodes, traceFile, cpuScaleDown, memScaleDown,
+                timeScaleDown, startTimeCutOff, affinityRequirementsProportion);
         emulatedClusterTest.runTraceLocally(numNodes, traceFile, cpuScaleDown, memScaleDown, timeScaleDown,
-                                            startTimeCutOff);
+                                            startTimeCutOff, affinityRequirementsProportion);
         System.exit(0); // without this, there are non-daemon threads that prevent JVM shutdown
     }
 }

--- a/k8s-scheduler/src/test/resources/pod-with-affinity.yml
+++ b/k8s-scheduler/src/test/resources/pod-with-affinity.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cache
+  labels:
+    app: store
+spec:
+  schedulerName: default-scheduler
+  containers:
+    - name: cache
+      image: k8s.gcr.io/pause
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - store
+          topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
(Attempt 2)

In this PR, we recreate the affinity views by unioning the results of separate select queries, so that indices can be used for each select query.

This PR also includes two other changes:

The PodEventsToDatabase class has changed, to modify pods with affinity requirements with the NotIn and DoesNotExist operator, to anti-affinity requirements with the In and Exists operator, and vice versa. SchedulerTests have been updated to pass with this change.
The EmulatedClusterTest is modified to add a flag: -p, which indicates the proportion of deployments that should be given affinity requirements. This flag is optional, so we get the old behavior of the test by simply not using it.