### PR TITLE
Release jars to sonatype/central

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ To learn more about DCM, we suggest going through the following research papers:
 
 ## Try it out
 
-### Pre-requisites
+### Maven dependency
+
+To use DCM from a Maven-based project, use the following dependency:
+
+```
+<dependency>
+    <groupId>com.vmware.dcm</groupId>
+    <artifactId>dcm</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+</dependency>
+```
+
+### Pre-requisites for developers
 
 1. Gradle and JDK 12 for building.
 
@@ -41,30 +53,13 @@ To learn more about DCM, we suggest going through the following research papers:
 
 3. We currently support two solver backends. Make sure to install both of them to run the build: 
 
-   * **MiniZinc (version 2.3.2)**. You can download it from: [https://www.minizinc.org/software.html](https://www.minizinc.org/software.html)
+   * **Google OR-tools CP-SAT (version 7.8)**. This is available by default when using the maven dependency. 
 
-     Make sure you are able to invoke the `minizinc` binary from your commandline.
-
-   * **Google OR-tools CP-SAT (version 7.8)**. To install, download the binary package (*not the flatzinc packages*) for your platform from: [https://github.com/google/or-tools/releases/tag/v7.8](https://github.com/google/or-tools/releases/tag/v7.8)
-
-     Untar the downloaded bundle and run the following command in the `<or-tools>/lib/` folder to install the or-tools jar file (requires Maven):
-
-     ```
-      $: mvn install:install-file -Dfile=com.google.ortools.jar -DgroupId=com.google -DartifactId=ortools -Dversion=7.8 -Dpackaging=jar
-     ```
-
-     Next, set up the following environment variable to point to the or-tools shared library:
-
-     On OSX:
-     ```
-      export OR_TOOLS_LIB=<or-tools>/lib/libjniortools.jnilib
-     ```
-
-     On Linux:
-     ```
-      export OR_TOOLS_LIB=<or-tools>/lib/libjniortools.so
-     
-     ```
+   * **MiniZinc (version 2.3.2)**. This backend is currently being deprecated. If you want to use it,
+   you will have to install MiniZinc out-of-band. 
+   
+   To do so, download MiniZinc from [https://www.minizinc.org/software.html](https://www.minizinc.org/software.html)
+   ... and make sure you are able to invoke the `minizinc` binary from your commandline.
 
 ### Building
 

--- a/benchmarks/src/main/java/com/vmware/dcm/BatchingBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/BatchingBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/benchmarks/src/main/java/com/vmware/dcm/EndToEndBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/EndToEndBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/benchmarks/src/main/java/com/vmware/dcm/H2Bench.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/H2Bench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/benchmarks/src/main/java/com/vmware/dcm/MiniZincEncodingBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/MiniZincEncodingBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/benchmarks/src/main/java/com/vmware/dcm/OrToolsEncodingBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/OrToolsEncodingBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/benchmarks/src/main/java/com/vmware/dcm/OrToolsIndexBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/OrToolsIndexBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        jcenter() // Used for community contributed or-tools package
     }
 
     dependencies {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright 2018-2020 VMware, Inc. All Rights Reserved.
   ~
   ~ SPDX-License-Identifier: BSD-2
   -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright 2018-2020 VMware, Inc. All Rights Reserved.
   ~
   ~ SPDX-License-Identifier: BSD-2
   -->

--- a/config/spotbugs/findbugs-exclude.xml
+++ b/config/spotbugs/findbugs-exclude.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright 2018-2020 VMware, Inc. All Rights Reserved.
   ~
   ~ SPDX-License-Identifier: BSD-2
   -->

--- a/dcm/build.gradle
+++ b/dcm/build.gradle
@@ -5,6 +5,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'signing'
 }
 
 dependencies {
@@ -25,6 +26,11 @@ description = 'dcm'
 // compileJava {
 //   options.compilerArgs = ["--release", "12"]
 // }
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
 
 publishing {
     repositories {
@@ -49,4 +55,8 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications.maven
 }

--- a/dcm/build.gradle
+++ b/dcm/build.gradle
@@ -15,7 +15,9 @@ dependencies {
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "com.facebook.presto:presto-parser:${prestoParserVersion}"
     implementation "com.squareup:javapoet:${javapoetVersion}"
-    implementation "com.google:ortools:${orToolsVersion}"
+    // implementation "com.google:ortools:${orToolsVersion}"
+    // Temporarily use community contributed or-tools package
+    implementation "com.skaggsm.ortools:ortools-natives-all:${orToolsVersion}"
     implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
     testImplementation "com.h2database:h2:${h2Version}"
 }

--- a/dcm/build.gradle
+++ b/dcm/build.gradle
@@ -33,11 +33,13 @@ java {
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/vmware/declarative-cluster-management")
+            name = "Sonatype"
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = project.hasProperty('release') ? releasesRepoUrl : snapshotsRepoUrl
             credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-                password = project.findProperty("gpr.key") ?: System.getenv("DCM_GITHUB_TOKEN")
+                username = project.findProperty("ossrhUsername")
+                password = project.findProperty("ossrhPassword")
             }
         }
     }
@@ -45,36 +47,35 @@ publishing {
     publications {
         maven(MavenPublication) {
             from(components.java)
+
             groupId = "${dcmGroupId}"
             artifactId = "${dcmArtifactId}"
             version = "${dcmVersion}"
-            url = "https://github.com/vmware/declarative-cluster-management/"
-
-            scm {
-                connection "scm:git:https://github.com/vmware/declarative-cluster-management.git"
-                developerConnection "scm:git:git@github.com:vmware/declarative-cluster-management.git"
-                url "https://github.com/vmware/declarative-cluster-management/"
-            }
 
             pom {
-                description = "Library for building declarative cluster managers.
-                               Please refer to the README at github.com/vmware/declarative-cluster-management/
-                               for instructions on setting up solvers before use."
-            }
+                url = "https://github.com/vmware/declarative-cluster-management/"
+                description = "Library for building declarative cluster managers. Please refer to the README at github.com/vmware/declarative-cluster-management/ for instructions on setting up solvers before use."
 
-            developers {
-                developer {
-                    id = "lalithsuresh"
-                    name = "Lalith Suresh"
-                    email = "lsuresh@vmware.com"
-                    url = "https://github.com/lalithsuresh"
+                developers {
+                    developer {
+                        id = "lalithsuresh"
+                        name = "Lalith Suresh"
+                        email = "lsuresh@vmware.com"
+                        url = "https://github.com/lalithsuresh"
+                    }
                 }
-            }
 
-            licenses {
-                license {
-                    name "The BSD-2 license"
-                    url "https://opensource.org/licenses/BSD-2-Clause"
+                scm {
+                    connection = "scm:git:https://github.com/vmware/declarative-cluster-management.git"
+                    developerConnection = "scm:git:git@github.com:vmware/declarative-cluster-management.git"
+                    url = "https://github.com/vmware/declarative-cluster-management/"
+                }
+
+                licenses {
+                    license {
+                        name = "The BSD-2 license"
+                        url = "https://opensource.org/licenses/BSD-2-Clause"
+                    }
                 }
             }
         }

--- a/dcm/build.gradle
+++ b/dcm/build.gradle
@@ -20,8 +20,6 @@ dependencies {
     testImplementation "com.h2database:h2:${h2Version}"
 }
 
-description = 'dcm'
-
 // Use this block to compile DCM for a specific JDK release
 // compileJava {
 //   options.compilerArgs = ["--release", "12"]
@@ -50,8 +48,34 @@ publishing {
             groupId = "${dcmGroupId}"
             artifactId = "${dcmArtifactId}"
             version = "${dcmVersion}"
+            url = "https://github.com/vmware/declarative-cluster-management/"
+
+            scm {
+                connection "scm:git:https://github.com/vmware/declarative-cluster-management.git"
+                developerConnection "scm:git:git@github.com:vmware/declarative-cluster-management.git"
+                url "https://github.com/vmware/declarative-cluster-management/"
+            }
+
             pom {
-                description = "Library for building declarative cluster managers. Please refer to the README at github.com/vmware/declarative-cluster-management/ for instructions on setting up solvers before use."
+                description = "Library for building declarative cluster managers.
+                               Please refer to the README at github.com/vmware/declarative-cluster-management/
+                               for instructions on setting up solvers before use."
+            }
+
+            developers {
+                developer {
+                    id = "lalithsuresh"
+                    name = "Lalith Suresh"
+                    email = "lsuresh@vmware.com"
+                    url = "https://github.com/lalithsuresh"
+                }
+            }
+
+            licenses {
+                license {
+                    name "The BSD-2 license"
+                    url "https://opensource.org/licenses/BSD-2-Clause"
+                }
             }
         }
     }

--- a/dcm/src/main/java/com/vmware/dcm/Conf.java
+++ b/dcm/src/main/java/com/vmware/dcm/Conf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/ExtractAccessedTables.java
+++ b/dcm/src/main/java/com/vmware/dcm/ExtractAccessedTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/ExtractGroupTable.java
+++ b/dcm/src/main/java/com/vmware/dcm/ExtractGroupTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/IRColumn.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRColumn.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 /**
  * Represents a jooqField within an SQL table used within MiniZinz models
- *
  */
 public class IRColumn {
     private static final String FIELD_PREFIX_SEP = "__";
@@ -105,6 +104,10 @@ public class IRColumn {
 
     /**
      * Builds a IRColumn from a SQL jooqField parsing its type and tags
+     * @param irTable the IRTable that this column belongs to
+     * @param jooqField the Field that this column corresponds to
+     * @param fieldType the FieldType of this column
+     * @param fieldNameInitial the initial name for this column
      */
     public IRColumn(@Nullable final IRTable irTable, @Nullable final Field jooqField,
                     final FieldType fieldType, final String fieldNameInitial) {
@@ -154,13 +157,15 @@ public class IRColumn {
 
     /**
      * Returns the IRTable corresponding to this IRColumn
+     * @return the IRTable corresponding to this IRColumn
      */
     public IRTable getIRTable() {
         return Preconditions.checkNotNull(irTable);
     }
 
     /**
-     * Returns the Jooq Field that backs an IRColumn
+     * Returns the Jooq Field that backs this IRColumn
+     * @return the Jooq Field that backs this IRColumn
      */
     public Field getJooqField() {
         return Preconditions.checkNotNull(jooqField);
@@ -168,6 +173,7 @@ public class IRColumn {
 
     /**
      * Used in the mnz_data.ftl and mnz_model.ftl template files
+     * @return the column name
      */
     public String getName() {
         return name;
@@ -175,6 +181,7 @@ public class IRColumn {
 
     /**
      * Used in the mnz_data.ftl and mnz_model.ftl template files
+     * @return the column's FieldType
      */
     public FieldType getType() {
         return Preconditions.checkNotNull(type);
@@ -182,6 +189,7 @@ public class IRColumn {
 
     /**
      * Sets the foreignKeyParent of this jooqField, if this jooqField is a ForeignKey from another table jooqField
+     * @param parent sets the foreign key paraent for this column
      */
     void setForeignKeyParent(final IRColumn parent) {
         Preconditions.checkNotNull(type);

--- a/dcm/src/main/java/com/vmware/dcm/IRColumn.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/IRContext.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRContext.java
@@ -118,7 +118,12 @@ public class IRContext {
      *************************/
 
     // TODO: this should ideally happen at input time.
-    public void addAliasedOrViewTable(final IRTable tableAlias) {
-        irTables.putIfAbsent(tableAlias.getAliasedName().toUpperCase(Locale.US), tableAlias);
+
+    /**
+     * Track an IRTable that is either an alias for an existing table or a view table
+     * @param table the alias or view table to track
+     */
+    public void addAliasedOrViewTable(final IRTable table) {
+        irTables.putIfAbsent(table.getAliasedName().toUpperCase(Locale.US), table);
     }
 }

--- a/dcm/src/main/java/com/vmware/dcm/IRContext.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/IRForeignKey.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/IRForeignKey.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRForeignKey.java
@@ -26,6 +26,8 @@ public class IRForeignKey {
      *
      * Has to be public so mnz_data.ftl and mnz_model.ftl template files can find the corresponding methods
      *
+     * @param childTable the child table in the FK relationship
+     * @param parentTable the parent table in the FK relationship
      * @param fk SQL foreign key field
      */
     IRForeignKey(final IRTable childTable, final IRTable parentTable, final ForeignKey<? extends Record, ?> fk) {
@@ -60,6 +62,7 @@ public class IRForeignKey {
 
     /**
      * Used in the mnz_data.ftl and mnz_model.ftl template files
+     * @return returns the child table in this FK relation
      */
     public IRTable getChildTable() {
         return childTable;
@@ -67,6 +70,7 @@ public class IRForeignKey {
 
     /**
      * Used in the mnz_data.ftl and mnz_model.ftl template files
+     * @return returns the fields represented in this FK relation
      */
     public Map<IRColumn, IRColumn> getFields() {
         return fields;
@@ -74,6 +78,7 @@ public class IRForeignKey {
 
     /**
      * Returns true if this foreign key is defined on a variable column, false otherwise
+     * @return true if this foreign key is defined on a variable column, false otherwise
      */
     public boolean hasConstraint() {
         return !this.fields.isEmpty() && this.hasControllableField();

--- a/dcm/src/main/java/com/vmware/dcm/IRPrimaryKey.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRPrimaryKey.java
@@ -32,6 +32,7 @@ public class IRPrimaryKey {
 
     /**
      * Returns all the fields that compose this primary key
+     * @return all the fields that compose this primary key
      */
     public List<IRColumn> getPrimaryKeyFields() {
         return primaryKeyFields;
@@ -39,11 +40,16 @@ public class IRPrimaryKey {
 
     /**
      * Returns true if this primaryKey has a controllable field
+     * @return true if this primaryKey has a controllable field
      */
     public boolean hasControllableColumn() {
         return primaryKeyFields.stream().anyMatch(IRColumn::isControllable);
     }
 
+    /**
+     * Returns the irTable for which this primary key is configured
+     * @return the irTable for which this primary key is configured
+     */
     public IRTable getIRTable() {
         return irTable;
     }

--- a/dcm/src/main/java/com/vmware/dcm/IRPrimaryKey.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRPrimaryKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/IRTable.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/IRTable.java
+++ b/dcm/src/main/java/com/vmware/dcm/IRTable.java
@@ -79,6 +79,7 @@ public class IRTable {
 
     /**
      * Returns the Jooq Table associated with this IRTable
+     * @return the Jooq Table associated with this IRTable
      */
     public Table<? extends Record> getTable() {
         return Preconditions.checkNotNull(jooqTable);
@@ -105,6 +106,7 @@ public class IRTable {
 
     /**
      * Returns the number of rows in the table backed by this IRTable
+     * @return the number of rows in the table backed by this IRTable
      */
     public int getNumRows() {
         Preconditions.checkNotNull(jooqTable);
@@ -114,6 +116,7 @@ public class IRTable {
 
     /**
      * Used in the mnz_data.ftl and mnz_model.ftl template files
+     * @return the table name corresponding to this IRTable
      */
     public String getName() {
         return name;
@@ -122,6 +125,7 @@ public class IRTable {
 
     /**
      * Used in the mnz_data.ftl and mnz_model.ftl template files
+     * @return the alias for this IRTable
      */
     public String getAliasedName() {
         return alias;
@@ -129,6 +133,7 @@ public class IRTable {
 
     /**
      * Adds a IRColumn to the table
+     * @param irColumn the field/column to add to this IRTable
      */
     public void addField(final IRColumn irColumn) {
         //add to map with all the irColumns so we update values more easily later
@@ -138,13 +143,13 @@ public class IRTable {
         }
     }
 
-
     public Optional<IRPrimaryKey> getPrimaryKey() {
         return Objects.requireNonNull(primaryKey);
     }
 
     /**
      * Sets this table primaryKey
+     * @param pk primary key to set
      */
     public void setPrimaryKey(final IRPrimaryKey pk) {
         Preconditions.checkNotNull(jooqTable);
@@ -154,6 +159,8 @@ public class IRTable {
     /**
      * Returns a list of foreign keys, where each one is Map between this table field, and the referenced
      * table foreign key field.
+     * @return a list of foreign keys, where each one is Map between this table field, and the referenced
+     *        table foreign key field.
      */
     public List<IRForeignKey> getForeignKeys() {
         Preconditions.checkNotNull(jooqTable);
@@ -172,6 +179,8 @@ public class IRTable {
 
     /**
      * Returns the IRColumn based on the SQL field
+     * @param field field to seaerch for
+     * @return the IRColumn corresponding to the `field` parameter
      */
     IRColumn getField(final Field field) {
         Preconditions.checkNotNull(jooqTable);
@@ -180,6 +189,7 @@ public class IRTable {
 
     /**
      * Updates a table field with a list of values
+     * @param recentData a result set to update this column to
      */
     void updateValues(final Result<? extends Record> recentData) {
         Preconditions.checkNotNull(jooqTable);
@@ -192,6 +202,7 @@ public class IRTable {
 
     /**
      * Get the most recently invoked result set for this table.
+     * @return the current result set for this column
      */
     public Result<? extends Record> getCurrentData() {
         Preconditions.checkNotNull(recentData);
@@ -232,6 +243,7 @@ public class IRTable {
 
     /**
      * Returns all the IRColumns of the current table
+     * @return all the IRColumns of the current table
      */
     public Map<String, IRColumn> getIRColumns() {
         return irColumns;

--- a/dcm/src/main/java/com/vmware/dcm/Model.java
+++ b/dcm/src/main/java/com/vmware/dcm/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/Model.java
+++ b/dcm/src/main/java/com/vmware/dcm/Model.java
@@ -221,7 +221,7 @@ public class Model {
      * tables have variable columns, they will reflect the changes made by the solver.
      *
      * @param tables a set of table names
-     * @return A map where keys correspond to the supplied "tables" parameter, and the values are Result<> objects
+     * @return A map where keys correspond to the supplied "tables" parameter, and the values are Result objects
      *         representing rows of the corresponding tables, with modifications made by the solver
      */
     public synchronized Map<String, Result<? extends Record>> solve(final Set<String> tables)
@@ -246,7 +246,7 @@ public class Model {
      * table has variable columns, the returned result will reflect the changes made by the solver.
      *
      * @param tableName a table name
-     * @return A Result<> object representing rows of the corresponding tables, with modifications made by the solver
+     * @return A Result object representing rows of the corresponding tables, with modifications made by the solver
      */
     public synchronized Result<? extends Record> solve(final String tableName)
             throws ModelException {

--- a/dcm/src/main/java/com/vmware/dcm/ModelException.java
+++ b/dcm/src/main/java/com/vmware/dcm/ModelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/RemoveControllablePredicates.java
+++ b/dcm/src/main/java/com/vmware/dcm/RemoveControllablePredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/ViewsWithChecks.java
+++ b/dcm/src/main/java/com/vmware/dcm/ViewsWithChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/annotations/FieldsAreNonnullByDefault.java
+++ b/dcm/src/main/java/com/vmware/dcm/annotations/FieldsAreNonnullByDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/annotations/MethodsAreNonnullByDefault.java
+++ b/dcm/src/main/java/com/vmware/dcm/annotations/MethodsAreNonnullByDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/DetectCapacityConstraints.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/DetectCapacityConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/backend/FindStringLiterals.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/FindStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/GetColumnIdentifiers.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/GetColumnIdentifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/GetVarQualifiers.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/GetVarQualifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/IGeneratedBackend.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/IGeneratedBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/InferType.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/InferType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/MinizincCodeGenerator.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/MinizincCodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/MinizincSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/MinizincSolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/MinizincString.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/MinizincString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/Ops.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/Ops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/OrToolsSolver.java
@@ -17,6 +17,7 @@ import com.google.ortools.sat.CpSolver;
 import com.google.ortools.sat.CpSolverStatus;
 import com.google.ortools.sat.IntVar;
 import com.google.ortools.util.Domain;
+import com.skaggsm.ortools.OrToolsHelper;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -30,14 +31,6 @@ import com.vmware.dcm.IRContext;
 import com.vmware.dcm.IRPrimaryKey;
 import com.vmware.dcm.IRTable;
 import com.vmware.dcm.ModelException;
-import com.vmware.dcm.compiler.monoid.GroupByQualifier;
-import com.vmware.dcm.compiler.monoid.IsNotNullPredicate;
-import com.vmware.dcm.compiler.monoid.MonoidFunction;
-import com.vmware.dcm.compiler.monoid.MonoidVisitor;
-import com.vmware.dcm.compiler.monoid.Qualifier;
-import com.vmware.dcm.compiler.monoid.TableRowGenerator;
-import com.vmware.dcm.compiler.monoid.VoidType;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.vmware.dcm.compiler.monoid.BinaryOperatorPredicate;
 import com.vmware.dcm.compiler.monoid.BinaryOperatorPredicateWithAggregate;
 import com.vmware.dcm.compiler.monoid.CheckQualifier;
@@ -45,12 +38,20 @@ import com.vmware.dcm.compiler.monoid.ColumnIdentifier;
 import com.vmware.dcm.compiler.monoid.ExistsPredicate;
 import com.vmware.dcm.compiler.monoid.Expr;
 import com.vmware.dcm.compiler.monoid.GroupByComprehension;
+import com.vmware.dcm.compiler.monoid.GroupByQualifier;
+import com.vmware.dcm.compiler.monoid.IsNotNullPredicate;
 import com.vmware.dcm.compiler.monoid.IsNullPredicate;
 import com.vmware.dcm.compiler.monoid.JoinPredicate;
 import com.vmware.dcm.compiler.monoid.MonoidComprehension;
+import com.vmware.dcm.compiler.monoid.MonoidFunction;
 import com.vmware.dcm.compiler.monoid.MonoidLiteral;
+import com.vmware.dcm.compiler.monoid.MonoidVisitor;
+import com.vmware.dcm.compiler.monoid.Qualifier;
 import com.vmware.dcm.compiler.monoid.SimpleVisitor;
+import com.vmware.dcm.compiler.monoid.TableRowGenerator;
 import com.vmware.dcm.compiler.monoid.UnaryOperator;
+import com.vmware.dcm.compiler.monoid.VoidType;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;
@@ -130,8 +131,7 @@ public class OrToolsSolver implements ISolverBackend {
     private final boolean configUseIndicesForEqualityBasedJoins;
 
     static {
-        Preconditions.checkNotNull(System.getenv(OR_TOOLS_LIB_ENV));
-        System.load(System.getenv(OR_TOOLS_LIB_ENV));
+        OrToolsHelper.loadLibrary();
     }
 
     @Nullable private IGeneratedBackend generatedBackend;

--- a/dcm/src/main/java/com/vmware/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/OrToolsSolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/OrToolsSolver.java
@@ -159,6 +159,7 @@ public class OrToolsSolver implements ISolverBackend {
         /**
          * Number of solver threads. Corresponds to CP-SAT's setNumSearchWorkers parameter.
          * @param numThreads number of solver threads to use. Defaults to {@value NUM_THREADS_DEFAULT}.
+         * @return the current Builder object with `numThreads` set
          */
         public Builder setNumThreads(final int numThreads) {
             this.numThreads = numThreads;
@@ -169,6 +170,7 @@ public class OrToolsSolver implements ISolverBackend {
          * Solver timeout. If this parameter is set too low for the problem size involved, expect a ModelException
          * for not finding a solution. Corresponds to CP-SAT's setNumSearchWorkers parameter.
          * @param maxTimeInSeconds timeout value in seconds. Defaults to {@value MAX_TIME_IN_SECONDS}.
+         * @return the current Builder object with `maxTimeInSeconds` set
          */
         public Builder setMaxTimeInSeconds(final int maxTimeInSeconds) {
             this.maxTimeInSeconds = maxTimeInSeconds;
@@ -179,6 +181,7 @@ public class OrToolsSolver implements ISolverBackend {
          * Configures whether we attempt to pattern match and apply an optimization that uses scalar products
          * in certain kinds of aggregates.
          * @param tryScalarProductEncoding true to apply scalar product optimization. Defaults to true.
+         * @return the current Builder object with `tryScalarProductEncoding` set
          */
         public Builder setTryScalarProductEncoding(final boolean tryScalarProductEncoding) {
             this.tryScalarProductEncoding = tryScalarProductEncoding;
@@ -190,6 +193,7 @@ public class OrToolsSolver implements ISolverBackend {
          * "spreading" joins.
          * @param useFullReifiedConstraintsForJoinPreferences uses full-reified encodings if true, half-reified
          *                                                    encodings otherwise. Defaults to false.
+         * @return the current Builder object with `useFullReifiedConstraintsForJoinPreferences` set
          */
         public Builder setUseFullReifiedConstraintsForJoinPreferences(final boolean
                                                                       useFullReifiedConstraintsForJoinPreferences) {
@@ -203,6 +207,7 @@ public class OrToolsSolver implements ISolverBackend {
          * loops in the generated code.
          *
          * @param useIndicesForEqualityBasedJoins generated code uses indexes if possible. Defaults to true.
+         * @return the current Builder object with `useIndicesForEqualityBasedJoins` set
          */
         public Builder setUseIndicesForEqualityBasedJoins(final boolean useIndicesForEqualityBasedJoins) {
             this.useIndicesForEqualityBasedJoins = useIndicesForEqualityBasedJoins;

--- a/dcm/src/main/java/com/vmware/dcm/backend/OutputIR.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/OutputIR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/RewriteArity.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/RewriteArity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/RewriteContains.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/RewriteContains.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/RewriteCountFunction.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/RewriteCountFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/RewriteNullPredicates.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/RewriteNullPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/SplitIntoSingleHeadComprehensions.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/SplitIntoSingleHeadComprehensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/StringEncoding.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/StringEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/TupleGen.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/TupleGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/backend/package-info.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/FromExtractor.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/FromExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/ModelCompiler.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/ModelCompiler.java
@@ -45,6 +45,8 @@ public class ModelCompiler {
     /**
      * Entry point to compile views into list comprehensions
      * @param views a list of strings, each of which is a view statement
+     * @param backend an ISolverBackend instance.
+     * @return A list of strings representing the program that was compiled
      */
     @CanIgnoreReturnValue
     public List<String> compile(final List<ViewsWithChecks> views, final ISolverBackend backend) {

--- a/dcm/src/main/java/com/vmware/dcm/compiler/ModelCompiler.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/ModelCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/ReferencedSymbols.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/ReferencedSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/TranslateViewToIR.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/TranslateViewToIR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/compiler/UsesAggregateFunctions.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/UsesAggregateFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/compiler/UsesControllableFields.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/UsesControllableFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/BinaryOperatorPredicate.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/BinaryOperatorPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/BinaryOperatorPredicateWithAggregate.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/BinaryOperatorPredicateWithAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/CheckQualifier.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/CheckQualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ColumnIdentifier.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ColumnIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ColumnIdentifier.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ColumnIdentifier.java
@@ -38,7 +38,7 @@ public class ColumnIdentifier extends Expr {
         return field.getIRTable().getAliasedName();
     }
 
-    /**
+    /*
      * True if this column was referenced in the original view using a dereference. False otherwise.
      * XXX: Is only consumed by the MiniZinc backend, and is likely not required
      */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ComprehensionRewriter.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ComprehensionRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ExistsPredicate.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/ExistsPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/Expr.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/Expr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/GroupByComprehension.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/GroupByComprehension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/GroupByQualifier.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/GroupByQualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/Head.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/Head.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/IsNotNullPredicate.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/IsNotNullPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/IsNullPredicate.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/IsNullPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/JoinPredicate.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/JoinPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidComprehension.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidComprehension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidFunction.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidLiteral.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidVisitor.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/MonoidVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/Qualifier.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/Qualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/SimpleVisitor.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/SimpleVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/TableRowGenerator.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/TableRowGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/UnaryOperator.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/UnaryOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/VoidType.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/VoidType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/dcm/src/main/java/com/vmware/dcm/compiler/monoid/package-info.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/monoid/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/compiler/package-info.java
+++ b/dcm/src/main/java/com/vmware/dcm/compiler/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/main/java/com/vmware/dcm/package-info.java
+++ b/dcm/src/main/java/com/vmware/dcm/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/test/java/com/vmware/dcm/ExtractGroupTablesTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/ExtractGroupTablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/test/java/com/vmware/dcm/ModelTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/test/java/com/vmware/dcm/backend/OpsTests.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/OpsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/test/java/com/vmware/dcm/backend/OrToolsIntervalsTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/OrToolsIntervalsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2019 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/test/java/com/vmware/dcm/backend/OrToolsTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/OrToolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/dcm/src/test/java/com/vmware/dcm/compiler/SqlToMnzCompilerTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/compiler/SqlToMnzCompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/examples/src/main/java/com/vmware/dcm/examples/LoadBalance.java
+++ b/examples/src/main/java/com/vmware/dcm/examples/LoadBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/examples/src/main/resources/log4j.properties
+++ b/examples/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+# Copyright 2018-2020 VMware, Inc. All Rights Reserved.
 #
 # SPDX-License-Identifier: BSD-2
 #

--- a/examples/src/test/java/com/vmware/dcm/examples/LoadBalanceTest.java
+++ b/examples/src/test/java/com/vmware/dcm/examples/LoadBalanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 commonSourceLevel = 12
 dcmGroupId = com.vmware.dcm
 dcmArtifactId = dcm
-dcmVersion = 0.2.0-SNAPSHOT
+dcmVersion = 0.2.0
 
 ## Dependency versions
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ commonsTextVersion = 1.4
 commonsIoVersion = 2.4
 prestoParserVersion = 0.238.2
 javapoetVersion = 1.11.1
-orToolsVersion = 7.8
+orToolsVersion = 7.8.7960
 protobufVersion = 3.8.0
 h2Version = 1.4.200
 

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/DBConnectionPool.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/DBConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/DebugUtils.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/DebugUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedCluster.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedPodDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedPodToNodeBinder.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedPodToNodeBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/IPodDeployer.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/IPodDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/IPodToNodeBinder.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/IPodToNodeBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesBinder.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesPodDeployer.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesPodDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesStateSync.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesStateSync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/NodeResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/NodeResourceEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/PodEvent.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/PodEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/PodEventsToDatabase.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/PodEventsToDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/PodResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/PodResourceEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/Policies.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/Policies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/Scheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/Utils.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/trace/TraceReplayer.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/trace/TraceReplayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/k8s-scheduler/src/main/resources/log4j2.xml
+++ b/k8s-scheduler/src/main/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+  ~ Copyright 2018-2020 VMware, Inc. All Rights Reserved.
   ~
   ~ SPDX-License-Identifier: BSD-2
   -->

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/ITBase.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/ITBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/KubernetesStateSyncTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/KubernetesStateSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerIT.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/WorkloadGeneratorIT.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/WorkloadGeneratorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-2
  */

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/WorkloadGeneratorTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/WorkloadGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 


### PR DESCRIPTION
Includes changes to manage DCM releases via sonatype and Maven central.

* Adds required metadata in dcm/build.gradle
* Bundles javadocs and sources with the released jars
* Signs the released artifacts using gpg
* Uses a community contributed or-tools maven dependency, rather than expecting users to set up a solver out-of-band
* Changes to copyright headers to avoid non-ascii characters