### PR TITLE
Compilable code snippets in documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       # run tests!
       - run: ./gradlew build test codeCoverageReport -i
       - run: bash <(curl -s https://codecov.io/bash) -f build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+      - run: bash verify_docs.sh
 
       # collect test metadata
       - run:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ repositories {
 Here is a [complete program](examples/src/test/java/com/vmware/dcm/examples/QuickStartTest.java) 
 that you can run to get a feel for DCM. 
 
+<!-- embedme examples/src/test/java/com/vmware/dcm/examples/QuickStartTest.java#L8-L61 -->
 ```java
 import com.vmware.dcm.Model;
 import org.jooq.DSLContext;
@@ -127,7 +128,7 @@ public class QuickStartTest {
         // A table representing tasks, that need to be assigned to machines by DCM.
         // To do so, create a variable column (prefixed by controllable__).
         conn.execute("create table tasks(task_id integer, controllable__worker_id integer, " +
-                     "foreign key (controllable__worker_id) references machines(id))");
+                "foreign key (controllable__worker_id) references machines(id))");
 
         // Add four machines
         conn.execute("insert into machines values(1)");
@@ -152,7 +153,7 @@ public class QuickStartTest {
 
         // Solve and return the tasks table. The controllable__worker_id column will either be [1, 5] or [5, 1]
         final List<Integer> column = model.solve("TASKS")
-                                          .map(e -> e.get("CONTROLLABLE__WORKER_ID", Integer.class));
+                .map(e -> e.get("CONTROLLABLE__WORKER_ID", Integer.class));
         assertEquals(2, column.size());
         assertTrue(column.contains(1));
         assertTrue(column.contains(5));
@@ -185,6 +186,14 @@ sure to setup both solvers first):
 
 ```bash
 $: ./gradlew build
+```
+
+To avoid documentation drift, code snippets in a documentation file (like the README or tutorial) 
+are embedded directly from source files that are continuously tested. To refresh these documentation
+files:
+
+```bash
+$: npx embedme <file>
 ```
 
 The Kubernetes scheduler also comes with integration tests that run against a real Kubernetes cluster. 

--- a/examples/src/main/resources/schema.sql
+++ b/examples/src/main/resources/schema.sql
@@ -8,7 +8,6 @@ create table physical_machine (
     memory_capacity integer
 );
 
-
 -- controllable__physical_machine represents a variable that the solver will assign values to
 create table virtual_machine (
     name varchar(30) primary key not null,

--- a/examples/src/test/java/com/vmware/dcm/examples/LoadBalanceTest.java
+++ b/examples/src/test/java/com/vmware/dcm/examples/LoadBalanceTest.java
@@ -75,7 +75,7 @@ public class LoadBalanceTest {
                 "  on physical_machine.name = virtual_machine.controllable__physical_machine " +
                 "group by physical_machine.name, physical_machine.cpu_capacity, physical_machine.memory_capacity " +
                 "check sum(virtual_machine.cpu) <= physical_machine.cpu_capacity and " +
-                "       sum(virtual_machine.memory) <= physical_machine.memory_capacity";
+                "      sum(virtual_machine.memory) <= physical_machine.memory_capacity";
 
         final String spareCpu = "create view spare_cpu as " +
                 "select physical_machine.cpu_capacity - sum(virtual_machine.cpu) as cpu_spare " +

--- a/verify_docs.sh
+++ b/verify_docs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+npx embedme README.md --verify
+npx embedme docs/tutorial.md --verify 


### PR DESCRIPTION
This uses the `embedme` utility to embed code snippets from source files into our documentation (like README.md and docs/tutorial.md). Doing so continuously tests these code snippets as part of our build, and also fails the build if a code snippet changes without being reflected in the linked documentation.