### PR TITLE
Ortools backend refactor

### DIFF
--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/ContainsMonoidFunction.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/ContainsMonoidFunction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm.backend.ortools;
+
+import com.vmware.dcm.compiler.monoid.MonoidFunction;
+import com.vmware.dcm.compiler.monoid.SimpleVisitor;
+import com.vmware.dcm.compiler.monoid.VoidType;
+
+class ContainsMonoidFunction extends SimpleVisitor {
+    boolean found = false;
+
+    @Override
+    protected VoidType visitMonoidFunction(final MonoidFunction node, final VoidType context) {
+        found = true;
+        return super.visitMonoidFunction(node, context);
+    }
+
+    boolean getFound() {
+        return found;
+    }
+}

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/GroupContext.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/GroupContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm.backend.ortools;
+
+import com.vmware.dcm.compiler.monoid.GroupByQualifier;
+
+// TODO: consolidate into TranslationContext
+class GroupContext {
+    private final GroupByQualifier qualifier;
+    private final String tempTableName;
+    private final String groupViewName;
+
+    GroupContext(final GroupByQualifier qualifier, final String tempTableName, final String groupViewName) {
+        this.qualifier = qualifier;
+        this.tempTableName = tempTableName;
+        this.groupViewName = groupViewName;
+    }
+
+    public GroupByQualifier getQualifier() {
+        return qualifier;
+    }
+
+    public String getTempTableName() {
+        return tempTableName;
+    }
+
+    public String getGroupViewName() {
+        return groupViewName;
+    }
+}

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/InferType.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/InferType.java
@@ -180,7 +180,7 @@ class InferType extends MonoidVisitor<String, VoidType> {
         }
     }
 
-    // TODO: passing viewTupleTypeParameters makes this class tightly coupled with OrToolsSolver.
+    // TODO: passing viewTupleTypeParameters makes this class tightly coupled with TupleMetadata.
     static String forExpr(final Expr expr, final Map<String, String> viewTupleTypeParameters) {
         final InferType visitor = new InferType(viewTupleTypeParameters);
         final String result = visitor.visit(expr);

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -1066,9 +1066,9 @@ public class OrToolsSolver implements ISolverBackend {
                     (name, field) -> {
                         // Else, we update the records corresponding to the table.
                         if (controllableColumns.contains(name)) {
-                            final int i = intermediateViewCounter.incrementAndGet();
-                            output.addStatement("final Result<? extends Record> tmp$L = " +
-                                    "context.getTable($S).getCurrentData()", i, tableName);
+                            final String tempViewName = getTempViewName();
+                            output.addStatement("final Result<? extends Record> $L = " +
+                                    "context.getTable($S).getCurrentData()", tempViewName, tableName);
                             output.beginControlFlow("for (int i = 0; i < $L; i++)",
                                     tableNumRowsStr(tableName));
                             if (field.getType().equals(IRColumn.FieldType.STRING)) {
@@ -1078,9 +1078,9 @@ public class OrToolsSolver implements ISolverBackend {
                                 output.addStatement("obj[0] = solver.value($L[i])",
                                         fieldNameStr(tableName, field.getName()));
                             }
-                            output.addStatement("tmp$L.get(i).from(obj, $S)", i, field.getName());
+                            output.addStatement("$L.get(i).from(obj, $S)", tempViewName, field.getName());
                             output.endControlFlow();
-                            output.addStatement("result.put(context.getTable($S), tmp$L)", tableName, i);
+                            output.addStatement("result.put(context.getTable($S), $L)", tableName, tempViewName);
                         }
                     }
                 );

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/SubQueryContext.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/SubQueryContext.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm.backend.ortools;
+
+// TODO: consolidate into TranslationContext
+class SubQueryContext {
+    private final String subQueryName;
+
+    SubQueryContext(final String subQueryName) {
+        this.subQueryName = subQueryName;
+    }
+
+    public String getSubQueryName() {
+        return subQueryName;
+    }
+}

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/TranslationContext.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/TranslationContext.java
@@ -8,14 +8,17 @@ package com.vmware.dcm.backend.ortools;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Represents context required for code generation. It maintains a stack of blocks
  * in the IR, that is used to correctly scope variable declarations and accesses.
  */
 class TranslationContext {
+    private static final String SUBQUERY_NAME_PREFIX = "subquery";
     private final Deque<OutputIR.Block> scopeStack;
     private final boolean isFunctionContext;
+    private final AtomicInteger subqueryCounter = new AtomicInteger(0);
 
     private TranslationContext(final Deque<OutputIR.Block> declarations, final boolean isFunctionContext) {
         this.scopeStack = declarations;
@@ -66,5 +69,9 @@ class TranslationContext {
 
     String getTupleVarName() {
         return currentScope().getTupleName();
+    }
+
+    String getNewSubqueryName() {
+        return SUBQUERY_NAME_PREFIX + subqueryCounter.incrementAndGet();
     }
 }

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/TupleMetadata.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/TupleMetadata.java
@@ -8,12 +8,16 @@ package com.vmware.dcm.backend.ortools;
 import com.google.common.base.Preconditions;
 import com.vmware.dcm.IRColumn;
 import com.vmware.dcm.IRTable;
+import com.vmware.dcm.compiler.monoid.ColumnIdentifier;
 import com.vmware.dcm.compiler.monoid.Expr;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
@@ -21,10 +25,13 @@ import java.util.stream.Collectors;
  * corresponding Java types. For example, a table with an integer and a variable
  * column will have the Java parameter type recorded as a String, "Integer, IntVar".
  */
-public class TypeTracker {
+public class TupleMetadata {
+    private static final String GENERATED_FIELD_NAME_PREFIX = "GenField";
+    private final AtomicInteger generatedFieldNameCounter = new AtomicInteger(0);
     private final Map<String, Map<String, String>> tableToFieldToType = new HashMap<>();
     private final Map<String, String> viewTupleTypeParameters = new HashMap<>();
     private final Map<String, String> viewGroupByTupleTypeParameters = new HashMap<>();
+    private final Map<String, Map<String, Integer>> viewToFieldIndex = new HashMap<>();
 
     String computeTableTupleType(final IRTable table) {
         Preconditions.checkArgument(!tableToFieldToType.containsKey(table.getAliasedName()));
@@ -49,6 +56,31 @@ public class TypeTracker {
         return viewTupleTypeParameters.compute(viewName, (k, v) -> generateTupleGenericParameters(exprs));
     }
 
+    /**
+     * Updates the tracked index for a field within a loop's result set
+     *
+     * @param viewName the view within which this expression is being visited
+     * @param exprs The expressions to create a field for
+     * @return A string representing the fields being accessed
+     */
+    <T extends Expr> String computeViewIndices(final String viewName, final List<T> exprs) {
+        final AtomicInteger counter = new AtomicInteger(0);
+        return exprs.stream().map(argument -> {
+                final String fieldName = argument.getAlias().orElseGet(() -> {
+                        if (argument instanceof ColumnIdentifier) {
+                            return ((ColumnIdentifier) argument).getField().getName();
+                        } else {
+                            return GENERATED_FIELD_NAME_PREFIX + generatedFieldNameCounter.getAndIncrement();
+                        }
+                    }
+                )
+                        .toUpperCase(Locale.US);
+                viewToFieldIndex.computeIfAbsent(viewName.toUpperCase(Locale.US), (k) -> new HashMap<>())
+                        .compute(fieldName, (k, v) -> counter.getAndIncrement());
+                return fieldName;
+            }
+        ).collect(Collectors.joining(",\n    "));
+    }
 
     String getGroupByTupleType(final String viewName) {
         return viewGroupByTupleTypeParameters.get(viewName);
@@ -64,6 +96,21 @@ public class TypeTracker {
 
     String getTypeForField(final String tableName, final String columnName) {
         return Objects.requireNonNull(tableToFieldToType.get(tableName).get(columnName));
+    }
+
+    boolean canBeAccessedWithViewIndices(final String tableName) {
+        return viewToFieldIndex.containsKey(tableName);
+    }
+
+    // when duplicates appear for viewToFieldIndex, we increment the fieldIndex counter but do not add a new
+    // entry. This means that the highest fieldIndex (and not the size of the map) is equal to tuple size.
+    // The indices are 0-indexed.
+    int getTupleSize(final String tableName) {
+        return Collections.max(viewToFieldIndex.get(tableName.toUpperCase(Locale.US)).values()) + 1;
+    }
+
+    int getViewIndexForField(final String tableName, final String columnName) {
+        return Objects.requireNonNull(viewToFieldIndex.get(tableName).get(columnName));
     }
 
     <T extends Expr> String generateTupleGenericParameters(final List<T> exprs) {

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/TypeTracker.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/TypeTracker.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm.backend.ortools;
+
+import com.google.common.base.Preconditions;
+import com.vmware.dcm.IRColumn;
+import com.vmware.dcm.IRTable;
+import com.vmware.dcm.compiler.monoid.Expr;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves the tuple types for tables, views and group by tables, into their
+ * corresponding Java types. For example, a table with an integer and a variable
+ * column will have the Java parameter type recorded as a String, "Integer, IntVar".
+ */
+public class TypeTracker {
+    private final Map<String, Map<String, String>> tableToFieldToType = new HashMap<>();
+    private final Map<String, String> viewTupleTypeParameters = new HashMap<>();
+    private final Map<String, String> viewGroupByTupleTypeParameters = new HashMap<>();
+
+    String computeTableTupleType(final IRTable table) {
+        Preconditions.checkArgument(!tableToFieldToType.containsKey(table.getAliasedName()));
+        return table.getIRColumns().entrySet().stream()
+                .map(e -> {
+                            final String retVal = InferType.typeStringFromColumn(e.getValue());
+                            // Tracks the type of each field.
+                            tableToFieldToType.computeIfAbsent(table.getAliasedName(), (k) -> new HashMap<>())
+                                    .putIfAbsent(e.getKey(), retVal);
+                            return retVal;
+                        }
+                ).collect(Collectors.joining(", "));
+    }
+
+    <T extends Expr> String computeGroupByTupleType(final String viewName, final List<T> exprs) {
+        Preconditions.checkArgument(!viewGroupByTupleTypeParameters.containsKey(viewName));
+        return viewGroupByTupleTypeParameters.compute(viewName, (k, v) -> generateTupleGenericParameters(exprs));
+    }
+
+    <T extends Expr> String computeViewTupleType(final String viewName, final List<T> exprs) {
+        Preconditions.checkArgument(!viewTupleTypeParameters.containsKey(viewName));
+        return viewTupleTypeParameters.compute(viewName, (k, v) -> generateTupleGenericParameters(exprs));
+    }
+
+
+    String getGroupByTupleType(final String viewName) {
+        return viewGroupByTupleTypeParameters.get(viewName);
+    }
+
+    String getViewTupleType(final String viewName) {
+        return viewTupleTypeParameters.get(viewName);
+    }
+
+    String getTypeForField(final IRTable table, final IRColumn column) {
+        return Objects.requireNonNull(tableToFieldToType.get(table.getName()).get(column.getName()));
+    }
+
+    String getTypeForField(final String tableName, final String columnName) {
+        return Objects.requireNonNull(tableToFieldToType.get(tableName).get(columnName));
+    }
+
+    <T extends Expr> String generateTupleGenericParameters(final List<T> exprs) {
+        return exprs.stream().map(this::inferType)
+                .collect(Collectors.joining(", "));
+    }
+
+    String inferType(final Expr expr) {
+        return InferType.forExpr(expr, viewTupleTypeParameters);
+    }
+}


### PR DESCRIPTION
Refactor out the code to compute/maintain tuple-related metadata into its own class. This includes both the types of different types of tuples (tables, views, group by expressions) and resolving field accesses to tuples we create into the correct index-based access.