### PR TITLE
k8s-scheduler: Handle null image list on NodeStatus

### DIFF
--- a/k8s-scheduler/src/main/java/com/vmware/dcm/NodeResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/NodeResourceEventHandler.java
@@ -303,7 +303,7 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
     private List<Insert<NodeImagesRecord>> addNodeImages(final DSLContext conn, final Node node) {
         final List<Insert<NodeImagesRecord>> inserts = new ArrayList<>();
         for (final ContainerImage image: node.getStatus().getImages()) {
-            for (final String imageName: image.getNames()) {
+            for (final String imageName: Optional.ofNullable(image.getNames()).orElse(Collections.emptyList())) {
                 final int imageSizeInMb = (int) (((float) image.getSizeBytes()) / 1024 / 1024);
                 inserts.add(
                     conn.insertInto(Tables.NODE_IMAGES)


### PR DESCRIPTION
NodeStatus image name can be null if there is a not tagged image in
node. This can happen if building image on Nodes without tagging or
untagging existing images.

Signed-off-by: Amir Ghassemi <ameretat.reith@gmail.com>