### PR TITLE
Uid based pod schedule

### DIFF
--- a/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedPodDeployer.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/EmulatedPodDeployer.java
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -30,7 +30,6 @@ public class EmulatedPodDeployer implements IPodDeployer {
     private final PodResourceEventHandler resourceEventHandler;
     private final String namespace;
     private final Map<String, List<Pod>> pods = new ConcurrentHashMap<>();
-    private final AtomicInteger uidCounter = new AtomicInteger(0);
 
     EmulatedPodDeployer(final PodResourceEventHandler podResourceEventHandler, final String namespace) {
         this.resourceEventHandler = podResourceEventHandler;
@@ -66,7 +65,7 @@ public class EmulatedPodDeployer implements IPodDeployer {
                 pod.getMetadata().setCreationTimestamp("" + System.currentTimeMillis());
                 pod.getMetadata().setNamespace(namespace);
                 pod.getMetadata().setResourceVersion("101");
-                pod.getMetadata().setUid("" + uidCounter.incrementAndGet());
+                pod.getMetadata().setUid(UUID.randomUUID().toString());
                 final OwnerReference reference = new OwnerReference();
                 reference.setName(deploymentName);
                 pod.getMetadata().setOwnerReferences(List.of(reference));

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesPodDeployer.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesPodDeployer.java
@@ -69,8 +69,7 @@ public class KubernetesPodDeployer implements IPodDeployer {
             LOG.info("Terminating deployment (name:{}, schedulerName:{}) with masterUrl {} at {}",
                     firstPodInDeployment.getMetadata().getName(), firstPodInDeployment.getSpec().getSchedulerName(),
                     fabricClient.getConfiguration().getMasterUrl(), System.currentTimeMillis());
-            fabricClient.pods().inNamespace(namespace)
-                               .delete(deployment);
+            fabricClient.pods().inNamespace(namespace).delete(deployment);
         }
     }
 }

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesStateSync.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/KubernetesStateSync.java
@@ -35,7 +35,7 @@ class KubernetesStateSync {
     }
 
     void setupInformersAndPodEventStream(final DBConnectionPool dbConnectionPool,
-                                                       final Consumer<PodEvent> podEventNotification) {
+                                         final Consumer<PodEvent> podEventNotification) {
         final SharedIndexInformer<Node> nodeSharedIndexInformer = sharedInformerFactory
                 .sharedIndexInformerFor(Node.class, NodeList.class, 30000);
         nodeSharedIndexInformer.addEventHandler(new NodeResourceEventHandler(dbConnectionPool, service));

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/NodeResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/NodeResourceEventHandler.java
@@ -182,6 +182,7 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
 
         final NodeInfo n = Tables.NODE_INFO;
         return conn.insertInto(Tables.NODE_INFO,
+                n.UID,
                 n.NAME,
                 n.UNSCHEDULABLE,
                 n.OUT_OF_DISK,
@@ -202,7 +203,8 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
                 n.MEMORY_ALLOCATED,
                 n.EPHEMERAL_STORAGE_ALLOCATED,
                 n.PODS_ALLOCATED)
-            .values(node.getMetadata().getName(),
+            .values(node.getMetadata().getUid(),
+                    node.getMetadata().getName(),
                     getUnschedulable,
                     outOfDisk,
                     memoryPressure,
@@ -224,6 +226,7 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
                     0L // pods allocated default
             )
             .onDuplicateKeyUpdate()
+            .set(n.UID, node.getMetadata().getUid())
             .set(n.NAME, node.getMetadata().getName())
             .set(n.UNSCHEDULABLE, getUnschedulable)
             .set(n.OUT_OF_DISK, outOfDisk)
@@ -274,7 +277,7 @@ class NodeResourceEventHandler implements ResourceEventHandler<Node> {
 
     private void deleteNode(final Node node, final DSLContext conn) {
         conn.deleteFrom(Tables.NODE_INFO)
-            .where(Tables.NODE_INFO.NAME.eq(node.getMetadata().getName()))
+            .where(Tables.NODE_INFO.UID.eq(node.getMetadata().getUid()))
             .execute();
         LOG.info("Node {} deleted", node.getMetadata().getName());
     }

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/PodEvent.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/PodEvent.java
@@ -36,7 +36,9 @@ class PodEvent {
     public String toString() {
         return "PodEvent{" +
                 "action=" + action.name() +
-                ", pod=" + pod.getMetadata().getName() +
+                ", uid=" + pod.getMetadata().getUid() +
+                ", name=" + pod.getMetadata().getName() +
+                ", namespace=" + pod.getMetadata().getNamespace() +
                 '}';
     }
 }

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/PodResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/PodResourceEventHandler.java
@@ -38,7 +38,7 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
 
 
     public void onAddSync(final Pod pod) {
-        LOG.trace("{} pod add received", pod.getMetadata().getName());
+        LOG.trace("{} (uid: {}) pod add received", pod.getMetadata().getName(), pod.getMetadata().getUid());
         podEventNotification.accept(new PodEvent(PodEvent.Action.ADDED, pod)); // might be better to add pods in a batch
 
     }
@@ -47,14 +47,15 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
         final String oldPodScheduler = oldPod.getSpec().getSchedulerName();
         final String newPodScheduler = newPod.getSpec().getSchedulerName();
         assert oldPodScheduler.equals(newPodScheduler);
-        LOG.trace("{} => {} pod update received", oldPod.getMetadata().getName(), newPod.getMetadata().getName());
+        LOG.trace("{} => {} (uid: {}) pod update received", oldPod.getMetadata().getName(),
+                  newPod.getMetadata().getName(), newPod.getMetadata().getUid());
         podEventNotification.accept(new PodEvent(PodEvent.Action.UPDATED, newPod));
     }
 
     public void onDeleteSync(final Pod pod, final boolean deletedFinalStateUnknown) {
         final long now = System.nanoTime();
-        LOG.trace("{} pod deleted ({}) in {}ns!", pod.getMetadata().getName(), deletedFinalStateUnknown,
-                                                  (System.nanoTime() - now));
+        LOG.trace("{} (uid: {}) pod deleted ({}) in {}ns!", pod.getMetadata().getName(), pod.getMetadata().getUid(),
+                  deletedFinalStateUnknown, (System.nanoTime() - now));
         podEventNotification.accept(new PodEvent(PodEvent.Action.DELETED, pod));
     }
 

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/PodResourceEventHandler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/PodResourceEventHandler.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 /**
  * Subscribes to Kubernetes pod events and streams them to a flowable. Notably, it does not write
- * it to the database unlike the NodeResourceEventHandler. We do this to have tigher control over
+ * it to the database unlike the NodeResourceEventHandler. We do this to have tighter control over
  * batching these writes to the database.
  */
 class PodResourceEventHandler implements ResourceEventHandler<Pod> {
@@ -45,7 +45,7 @@ class PodResourceEventHandler implements ResourceEventHandler<Pod> {
 
     public void onUpdateSync(final Pod oldPod, final Pod newPod) {
         final String oldPodScheduler = oldPod.getSpec().getSchedulerName();
-        final String newPodScheduler = oldPod.getSpec().getSchedulerName();
+        final String newPodScheduler = newPod.getSpec().getSchedulerName();
         assert oldPodScheduler.equals(newPodScheduler);
         LOG.trace("{} => {} pod update received", oldPod.getMetadata().getName(), newPod.getMetadata().getName());
         podEventNotification.accept(new PodEvent(PodEvent.Action.UPDATED, newPod));

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/KubernetesStateSyncTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/KubernetesStateSyncTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nullable;
 import java.net.HttpURLConnection;
 import java.util.Collections;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -53,12 +54,14 @@ public class KubernetesStateSyncTest {
         final String rv2 = "11";
         final String rv3 = "12";
         final String rv4 = "13";
+        final String podUid = UUID.randomUUID().toString();
         assertNotNull(server);
         final NamespacedKubernetesClient client = server.getClient();
         final Node node = SchedulerTest.newNode("n1", Collections.emptyMap(), Collections.emptyList());
         final PodBuilder podBuilder = new PodBuilder().withNewMetadata()
                                                          .withName("pod1")
                                                          .withNamespace("test")
+                                                         .withUid(podUid)
                                                          .withCreationTimestamp("10")
                                                          .withResourceVersion(rv2)
                                                       .endMetadata()

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerIT.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerIT.java
@@ -61,7 +61,7 @@ public class SchedulerIT extends ITBase {
         final List<Pod> items =
                 fabricClient.pods().inNamespace(TEST_NAMESPACE).list().getItems();
         assertEquals(newPodsToCreate, items.size());
-        items.forEach(pod -> assertNotEquals(pod.getSpec().getNodeName(), "kube-master"));
+        items.forEach(pod -> assertNotEquals("kube-master", pod.getSpec().getNodeName()));
         stateSync.shutdown();
         scheduler.shutdown();
     }
@@ -91,7 +91,7 @@ public class SchedulerIT extends ITBase {
         waitUntil(fabricClient, (n) -> hasNRunningPods(newPodsToCreate));
         final List<Pod> items = fabricClient.pods().inNamespace(TEST_NAMESPACE).list().getItems();
         assertEquals(newPodsToCreate, items.size());
-        items.forEach(pod -> assertNotEquals(pod.getSpec().getNodeName(), "kube-master"));
+        items.forEach(pod -> assertNotEquals("kube-master", pod.getSpec().getNodeName()));
 
         final Map<String, List<String>> podsByNode = new HashMap<>();
 

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerTest.java
@@ -104,23 +104,23 @@ public class SchedulerTest {
         final DSLContext conn = dbConnectionPool.getConnectionToDb();
         final Runnable checkThatResourcesNotReflected = () -> conn.selectFrom(Tables.NODE_INFO).fetch()
                                         .forEach(r -> {
-                                            assertEquals(r.getCpuAllocated(), 0);
-                                            assertEquals(r.getMemoryAllocated(), 0);
-                                            assertEquals(r.getEphemeralStorageAllocated(), 0);
-                                            assertEquals(r.getPodsAllocated(), 1);
+                                            assertEquals(0, r.getCpuAllocated());
+                                            assertEquals(0, r.getMemoryAllocated());
+                                            assertEquals(0, r.getEphemeralStorageAllocated());
+                                            assertEquals(1, r.getPodsAllocated());
                                         });
         final Runnable checkThatResourcesReflected = () -> conn.selectFrom(Tables.NODE_INFO).fetch()
                         .forEach(r -> {
                             if (!r.getName().equals("n5")) {
-                                assertEquals(r.getCpuAllocated(), 0);
-                                assertEquals(r.getMemoryAllocated(), 0);
-                                assertEquals(r.getEphemeralStorageAllocated(), 0);
-                                assertEquals(r.getPodsAllocated(), 1);
+                                assertEquals(0, r.getCpuAllocated());
+                                assertEquals(0, r.getMemoryAllocated());
+                                assertEquals(0, r.getEphemeralStorageAllocated());
+                                assertEquals(1, r.getPodsAllocated());
                             } else {
-                                assertEquals(r.getCpuAllocated(), 10000);
-                                assertEquals(r.getMemoryAllocated(), 1);
-                                assertEquals(r.getEphemeralStorageAllocated(), 0);
-                                assertEquals(r.getPodsAllocated(), 2);
+                                assertEquals(10000, r.getCpuAllocated());
+                                assertEquals(1, r.getMemoryAllocated());
+                                assertEquals(0, r.getEphemeralStorageAllocated());
+                                assertEquals(2, r.getPodsAllocated());
                             }
                         });
 

--- a/k8s-scheduler/src/test/resources/app-no-constraints.yml
+++ b/k8s-scheduler/src/test/resources/app-no-constraints.yml
@@ -16,3 +16,4 @@ spec:
       containers:
         - name: cache
           image: k8s.gcr.io/pause
+          imagePullPolicy: IfNotPresent

--- a/k8s-scheduler/src/test/resources/cache-example.yml
+++ b/k8s-scheduler/src/test/resources/cache-example.yml
@@ -26,3 +26,4 @@ spec:
       containers:
         - name: cache
           image: k8s.gcr.io/pause
+          imagePullPolicy: IfNotPresent

--- a/k8s-scheduler/src/test/resources/no-constraints.yml
+++ b/k8s-scheduler/src/test/resources/no-constraints.yml
@@ -16,5 +16,6 @@ spec:
       containers:
         - name: nginx
           image: nginx:1.7.9
+          imaePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/k8s-scheduler/src/test/resources/pod-only.yml
+++ b/k8s-scheduler/src/test/resources/pod-only.yml
@@ -9,3 +9,4 @@ spec:
   containers:
     - name: cache
       image: k8s.gcr.io/pause
+      imagePullPolicy: IfNotPresent

--- a/k8s-scheduler/src/test/resources/pod-with-affinity.yml
+++ b/k8s-scheduler/src/test/resources/pod-with-affinity.yml
@@ -9,6 +9,7 @@ spec:
   containers:
     - name: cache
       image: k8s.gcr.io/pause
+      imagePullPolicy: IfNotPresent
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s-scheduler/src/test/resources/web-store-example.yml
+++ b/k8s-scheduler/src/test/resources/web-store-example.yml
@@ -35,3 +35,4 @@ spec:
       containers:
         - name: web-app
           image: k8s.gcr.io/pause
+          imagePullPolicy: IfNotPresent


### PR DESCRIPTION
To schedule Pods with same name in different namespaces correctly,
reference related tables using pod_info.uid.

This commit also resized some table fields in according to kubernetes
restrictions. Resource names (Pod, Namespace or Node) can be named up to
253 characters long. Labels (including Taint and Tolerations) can have
keys up to 317 characters long and values up to 63 characters long.
