### PR TITLE
UNSAT core interface

### DIFF
--- a/dcm/src/main/java/com/vmware/dcm/SolverException.java
+++ b/dcm/src/main/java/com/vmware/dcm/SolverException.java
@@ -5,15 +5,35 @@
 
 package com.vmware.dcm;
 
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An exception thrown when invoking the solver. Typically used to convey infeasibility or some other error.
+ *
+ * Optionally returns an UNSAT core, if the solver supports it.
+ */
 public class SolverException extends RuntimeException {
     private final String reason;
+    private final List<String> core;
 
     public SolverException(final String reason) {
         super(reason);
         this.reason = reason;
+        this.core = Collections.emptyList();
+    }
+
+    public SolverException(final String reason, final List<String> core) {
+        super(reason);
+        this.reason = reason;
+        this.core = core;
     }
 
     public String reason() {
         return reason;
+    }
+
+    public List<String> core() {
+        return core;
     }
 }

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/Ops.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/Ops.java
@@ -772,4 +772,21 @@ public class Ops {
     public void maximize(final List<IntVar> list) {
         list.forEach(model::maximize);
     }
+
+    /*
+     * Assumes var is true
+     */
+    public void assume(final IntVar var, final String name) {
+        model.getBuilder().getVariables(var.getIndex()).toBuilder().setName(name).build();
+        model.addAssumption(var);
+    }
+
+    /*
+     * Assume "left implies right" is true
+     */
+    public void assumeImplication(final IntVar left, final IntVar right, final String name) {
+        final Literal assumptionLiteral = model.newBoolVar(name);
+        model.addImplication(left, right).onlyEnforceIf(assumptionLiteral);
+        model.addAssumption(assumptionLiteral);
+    }
 }

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -742,11 +742,13 @@ public class OrToolsSolver implements ISolverBackend {
                                               final TranslationContext context) {
         Preconditions.checkArgument(expr instanceof BinaryOperatorPredicate);
         final String statement = maybeWrapped(expr, context);
-
         if (joinPredicateStr.isEmpty()) {
-            return CodeBlock.builder().addStatement("model.addEquality($L, 1)", statement).build();
+            return CodeBlock.builder().addStatement("o.assume($L, $S)",
+                                                    statement, context.currentScope().getName())
+                            .build();
         } else {
-            return CodeBlock.builder().addStatement("model.addImplication($L, $L)", joinPredicateStr, statement)
+            return CodeBlock.builder().addStatement("o.assumeImplication($L, $L, $S)",
+                                                    joinPredicateStr, statement, context.currentScope().getName())
                             .build();
         }
     }

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -984,7 +984,8 @@ public class OrToolsSolver implements ISolverBackend {
         }
         output.addStatement("return result");
         output.endControlFlow();
-        output.addStatement("throw new $T(status.toString())", SolverException.class);
+        output.addStatement("final List<String> failedConstraints = o.findSufficientAssumptions(solver)");
+        output.addStatement("throw new $T(status.toString(), failedConstraints)", SolverException.class);
     }
 
     private static String tableNameStr(final String tableName) {
@@ -1273,7 +1274,9 @@ public class OrToolsSolver implements ISolverBackend {
                         break;
                     }
                 case ALL_DIFFERENT:
-                    context.currentScope().addBody(statement("o.allDifferent($L)", listOfProcessedItem.asString()));
+                    context.currentScope().addBody(
+                            statement("o.allDifferent($L, $S)", listOfProcessedItem.asString(),
+                                                                 context.currentScope().getName()));
                     return context.declare("model.newConstant(1)",  JavaType.IntVar);
                 case INCREASING:
                     context.currentScope().addBody(statement("o.increasing($L)", listOfProcessedItem.asString()));

--- a/dcm/src/test/java/com/vmware/dcm/ModelTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/ModelTest.java
@@ -232,6 +232,36 @@ public class ModelTest {
         assertEquals(3, controllableVars.size());
     }
 
+
+    @Test
+    public void allDifferentInfeasibilityTest() {
+        final DSLContext conn = DSL.using("jdbc:h2:mem:");
+        conn.execute("create table t1(id integer, controllable__var integer)");
+
+        final String allDifferent = "create view constraint_all_different as " +
+                "select * from t1 check all_different(controllable__var) = true";
+
+        final String domain1 = "create view constraint_domain as " +
+                "select * from t1 check controllable__var >= 1 and controllable__var <= 2";
+
+        final String domain2 = "create view constraint_domain_3 as " +
+                "select * from t1 check id != 1 or controllable__var = 1";
+
+        conn.execute("insert into t1 values (1, null)");
+        conn.execute("insert into t1 values (2, null)");
+        conn.execute("insert into t1 values (3, null)");
+
+        final Model model = Model.build(conn, List.of(allDifferent, domain1, domain2));
+        model.updateData();
+
+        try {
+            model.solve("T1");
+            fail();
+        } catch (final SolverException exception) {
+            assertTrue(exception.core().containsAll(List.of("constraint_all_different", "constraint_domain")));
+        }
+    }
+
     @Test
     public void whereClauseWithChecks() {
         final DSLContext conn = DSL.using("jdbc:h2:mem:");

--- a/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
@@ -10,12 +10,13 @@ import com.google.ortools.sat.CpSolver;
 import com.google.ortools.sat.CpSolverStatus;
 import com.google.ortools.sat.IntVar;
 import com.google.ortools.sat.LinearExpr;
-import com.google.ortools.sat.Literal;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CoreTest {
     static {
@@ -43,9 +44,11 @@ public class CoreTest {
         final CpSolverStatus status = solver.solve(model);
 
         assertEquals(CpSolverStatus.INFEASIBLE, status);
-        for (final int varIndex: solver.sufficientAssumptionsForInfeasibility()) {
-            System.out.println(model.getBuilder().getVariables(varIndex).getName()); // correctly prints variable "v1"
-        }
+        assertTrue(solver.sufficientAssumptionsForInfeasibility()
+                .stream()
+                .map(e -> model.getBuilder().getVariables(e).getName())
+                .collect(Collectors.toList())
+                .contains("v1"));
     }
 
     @Test
@@ -70,9 +73,10 @@ public class CoreTest {
         final CpSolverStatus status = solver.solve(model);
 
         assertEquals(CpSolverStatus.INFEASIBLE, status);
-        for (final int varIndex: solver.sufficientAssumptionsForInfeasibility()) {
-            System.out.println(varIndex);
-            System.out.println(model.getBuilder().getVariables(varIndex).getName()); // correctly prints variable "v1"
-        }
+        assertTrue(solver.sufficientAssumptionsForInfeasibility()
+                .stream()
+                .map(e -> model.getBuilder().getVariables(e).getName())
+                .collect(Collectors.toList())
+                .containsAll(List.of("i1 constraint_all_different", "i1 constraint_domain")));
     }
 }

--- a/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2018-2021 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm.backend.ortools;
+
+import com.google.ortools.sat.CpModel;
+import com.google.ortools.sat.CpSolver;
+import com.google.ortools.sat.CpSolverStatus;
+import com.google.ortools.sat.IntVar;
+import com.google.ortools.sat.LinearExpr;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CoreTest {
+    static {
+        // Causes or-tools JNI library to be loaded
+        new OrToolsSolver.Builder().build();
+    }
+
+    @Test
+    public void assumptionsTest() {
+        final CpModel model = new CpModel();
+        final IntVar i1 = model.newIntVar(0, 5, "i1");
+        final IntVar i2 = model.newIntVar(0, 5, "i2");
+        final IntVar v1 = model.newBoolVar("v1");
+        final IntVar v2 = model.newBoolVar("v2");
+
+        model.addGreaterOrEqual(LinearExpr.sum(new IntVar[]{i1, i2}), 11).onlyEnforceIf(v1); // can't be satisfied
+        model.addLessOrEqual(LinearExpr.sum(new IntVar[]{i1, i2}), 5).onlyEnforceIf(v2);
+        model.addAssumption(v1);
+        model.addAssumption(v2);
+        final CpSolver solver = new CpSolver();
+        final CpSolverStatus status = solver.solve(model);
+
+        assertEquals(CpSolverStatus.INFEASIBLE, status);
+        for (final int varIndex: solver.sufficientAssumptionsForInfeasibility()) {
+            System.out.println(varIndex);
+            System.out.println(model.getBuilder().getVariables(varIndex).getName()); // correctly prints variable "v1"
+        }
+    }
+}

--- a/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
@@ -10,7 +10,10 @@ import com.google.ortools.sat.CpSolver;
 import com.google.ortools.sat.CpSolverStatus;
 import com.google.ortools.sat.IntVar;
 import com.google.ortools.sat.LinearExpr;
+import com.google.ortools.sat.Literal;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -27,12 +30,43 @@ public class CoreTest {
         final IntVar i2 = model.newIntVar(0, 5, "i2");
         final IntVar v1 = model.newBoolVar("v1");
         final IntVar v2 = model.newBoolVar("v2");
+        final IntVar v3 = model.newBoolVar("v3");
 
         model.addGreaterOrEqual(LinearExpr.sum(new IntVar[]{i1, i2}), 11).onlyEnforceIf(v1); // can't be satisfied
         model.addLessOrEqual(LinearExpr.sum(new IntVar[]{i1, i2}), 5).onlyEnforceIf(v2);
+        model.addEquality(v3, 1);
         model.addAssumption(v1);
         model.addAssumption(v2);
+        model.addAssumption(v3);
         final CpSolver solver = new CpSolver();
+        solver.getParameters().setNumSearchWorkers(1);
+        final CpSolverStatus status = solver.solve(model);
+
+        assertEquals(CpSolverStatus.INFEASIBLE, status);
+        for (final int varIndex: solver.sufficientAssumptionsForInfeasibility()) {
+            System.out.println(model.getBuilder().getVariables(varIndex).getName()); // correctly prints variable "v1"
+        }
+    }
+
+    @Test
+    public void assumptionsTestWithOps() {
+        final CpModel model = new CpModel();
+        final StringEncoding encoding = new StringEncoding();
+        final Ops o = new Ops(model, encoding);
+        final IntVar i1 = model.newIntVar(0, 5, "i1");
+        final IntVar i2 = model.newIntVar(0, 5, "i2");
+        final IntVar i3 = model.newIntVar(0, 5, "i2");
+
+        o.assume(o.eq(i1, 3), "i1 constraint_all_different");
+        o.assume(model.newConstant(1), "i2 constraint_all_different");
+        o.assume(model.newConstant(1), "i3 constraint_all_different");
+
+        o.assume(o.and(o.leq(i1, 2), o.geq(i1, 1)), "i1 constraint_domain");
+        o.assume(o.and(o.leq(i2, 2), o.geq(i2, 1)), "i2 constraint_domain");
+        o.assume(o.and(o.leq(i3, 2), o.geq(i3, 1)), "i3 constraint_domain");
+        final CpSolver solver = new CpSolver();
+        solver.getParameters().setLogSearchProgress(true);
+        solver.getParameters().setNumSearchWorkers(1);
         final CpSolverStatus status = solver.solve(model);
 
         assertEquals(CpSolverStatus.INFEASIBLE, status);

--- a/dcm/src/test/java/com/vmware/dcm/backend/ortools/OpsTests.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/ortools/OpsTests.java
@@ -32,8 +32,7 @@ public class OpsTests {
 
     static {
         // Causes or-tools JNI library to be loaded
-        final OrToolsSolver builder = new OrToolsSolver.Builder().build();
-        System.out.println(builder);
+        new OrToolsSolver.Builder().build();
     }
 
     @Nullable private CpModel model;


### PR DESCRIPTION
Now that the or-tools backend exposes an UNSAT core interface (https://google.github.io/or-tools/java/CpModel_8java_source.html#l00994), it's time to add an official API to DCM. This PR adds a simple version of an UNSAT core interface. 

An infeasible model throws a `SolverException`, which now has a `core()` method. This returns a `List<String>` which correspond to the names of constraints that were unsatisfiable in the input model.

The list of constraints is guaranteed to be sufficient, but not necessarily minimal (but will be with high probability though).

Over time, we want to evolve from a `List<String>` to a table-based API that talks about failed constraints with respect to rows in the variable columns or relation with variable columns. Doing so would provide more fine-grained information to the developer and can even be programmatically consumed in the cluster manager's decision making.

Completes #74