### PR TITLE
[#101] ortools-backend: improve intermediate view type inferrence

### DIFF
--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/JavaTypeList.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/JavaTypeList.java
@@ -18,8 +18,8 @@ class JavaTypeList {
         this.typeList = typeList;
     }
 
-    boolean contains(final JavaType type) {
-        return typeList.contains(type);
+    JavaType get(final int index) {
+        return typeList.get(index);
     }
 
     @Override

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/TupleMetadata.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/TupleMetadata.java
@@ -100,6 +100,6 @@ public class TupleMetadata {
     }
 
     JavaType inferType(final Expr expr) {
-        return InferType.forExpr(expr, viewTupleTypeParameters);
+        return InferType.forExpr(expr, viewTupleTypeParameters, viewToFieldIndex);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 commonSourceLevel = 12
 dcmGroupId = com.vmware.dcm
 dcmArtifactId = dcm
-dcmVersion = 0.10.0
+dcmVersion = 0.11.0-SNAPSHOT
 
 ## Dependency versions
 


### PR DESCRIPTION
Avoid assuming that column types in derived views are always `IntVars`.

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>