### PR TITLE
dcm: simplify Model and ISolverBackend APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ public class QuickStartTest {
 ### Documentation
 
 The [Model](dcm/src/main/java/com/vmware/dcm/Model.java) class serves as DCM's public API. It exposes
-three methods: `Model.build()`, `model.updateData()` and `model.solve()`. 
+two methods: `Model.build()` and `model.solve()`. 
 
 * Check out the [tutorial](docs/tutorial.md) to learn how to use DCM by building a simple VM load balancer
 * Check out our [research papers](#learn-more) for the back story behind DCM

--- a/benchmarks/src/main/java/com/vmware/dcm/OrToolsEncodingBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/OrToolsEncodingBenchmark.java
@@ -108,7 +108,6 @@ public class OrToolsEncodingBenchmark {
                     .setMaxTimeInSeconds(100)
                     .build();
             model = Model.build(conn, solver, views);
-            model.updateData();
         }
 
         @CanIgnoreReturnValue

--- a/benchmarks/src/main/java/com/vmware/dcm/OrToolsIndexBenchmark.java
+++ b/benchmarks/src/main/java/com/vmware/dcm/OrToolsIndexBenchmark.java
@@ -77,7 +77,6 @@ public class OrToolsIndexBenchmark {
                     .setUseIndicesForEqualityBasedJoins(useIndex)
                     .build();
             model = Model.build(conn, solver, views);
-            model.updateData();
         }
 
         @CanIgnoreReturnValue

--- a/dcm/src/main/java/com/vmware/dcm/Model.java
+++ b/dcm/src/main/java/com/vmware/dcm/Model.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 public class Model {
     private static final Logger LOG = LoggerFactory.getLogger(Model.class);
     private final DSLContext dbCtx;
-    private final Map<String, IRTable> irTables;
     private final List<Table<? extends Record>> jooqTables;
     private final ISolverBackend backend;
 
@@ -104,7 +103,7 @@ public class Model {
 
         // parse model from SQL tables
         jooqTables = augmentedTableList;
-        irTables = parseModel(augmentedTableList);
+        final Map<String, IRTable> irTables = parseModel(augmentedTableList);
         final IRContext irContext = new IRContext(irTables);
         final ModelCompiler compiler = new ModelCompiler(irContext);
         compiler.compile(constraintViews, backend);
@@ -198,7 +197,7 @@ public class Model {
         LOG.info("Running the solver");
         final long start = System.nanoTime();
         final Map<String, Result<? extends Record>> inputRecords = fetchRecords(fetcher);
-        final Map<String, Result<? extends Record>> recordsPerTable = backend.runSolver(irTables, inputRecords);
+        final Map<String, Result<? extends Record>> recordsPerTable = backend.runSolver(inputRecords);
         LOG.info("Solver has run successfully in {}ns. Processing records.", System.nanoTime() - start);
         final Map<String, Result<? extends Record>> recordsToReturn = new HashMap<>();
         for (final Map.Entry<String, Result<? extends Record>> entry: recordsPerTable.entrySet()) {

--- a/dcm/src/main/java/com/vmware/dcm/Model.java
+++ b/dcm/src/main/java/com/vmware/dcm/Model.java
@@ -42,8 +42,7 @@ import java.util.stream.Collectors;
  * The public API for Model involves three narrow interfaces:
  *
  *   - buildModel() to create Model instances based on a supplied JOOQ DSLContext.
- *   - updateData() to extract the input data for the Model that we can then feed to solvers.
- *   - solveModel() to solve the current model based on the current modelFile and dataFile
+ *   - solve() to solve the current model based on the current modelFile and dataFile
  */
 public class Model {
     private static final Logger LOG = LoggerFactory.getLogger(Model.class);

--- a/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
@@ -7,7 +7,6 @@
 package com.vmware.dcm.backend;
 
 import com.vmware.dcm.IRContext;
-import com.vmware.dcm.IRTable;
 import com.vmware.dcm.compiler.Program;
 import com.vmware.dcm.compiler.ir.ListComprehension;
 import org.jooq.Record;
@@ -17,8 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface ISolverBackend {
-    Map<String, Result<? extends Record>> runSolver(final Map<String, IRTable> irTables,
-                                                    final Map<String, Result<? extends Record>> inputRecords);
+    Map<String, Result<? extends Record>> runSolver(final Map<String, Result<? extends Record>> inputRecords);
 
     List<String> generateModelCode(final IRContext context, final Program<ListComprehension> irProgram);
 

--- a/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
@@ -10,7 +10,6 @@ import com.vmware.dcm.IRContext;
 import com.vmware.dcm.IRTable;
 import com.vmware.dcm.compiler.Program;
 import com.vmware.dcm.compiler.ir.ListComprehension;
-import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;
 
@@ -18,8 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface ISolverBackend {
-    Map<String, Result<? extends Record>> runSolver(final DSLContext dbCtx,
-                                                    final Map<String, IRTable> irTables,
+    Map<String, Result<? extends Record>> runSolver(final Map<String, IRTable> irTables,
                                                     final Map<String, Result<? extends Record>> inputRecords);
 
     List<String> generateModelCode(final IRContext context, final Program<ListComprehension> irProgram);

--- a/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ISolverBackend.java
@@ -19,11 +19,10 @@ import java.util.Map;
 
 public interface ISolverBackend {
     Map<String, Result<? extends Record>> runSolver(final DSLContext dbCtx,
-                                                    final Map<String, IRTable> irTables);
+                                                    final Map<String, IRTable> irTables,
+                                                    final Map<String, Result<? extends Record>> inputRecords);
 
     List<String> generateModelCode(final IRContext context, final Program<ListComprehension> irProgram);
-
-    List<String> generateDataCode(final IRContext context, final Map<String, Result<? extends Record>> records);
 
     boolean needsGroupTables();
 }

--- a/dcm/src/main/java/com/vmware/dcm/backend/minizinc/MinizincSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/minizinc/MinizincSolver.java
@@ -113,7 +113,9 @@ public class MinizincSolver implements ISolverBackend {
 
     @Override
     public Map<String, Result<? extends Record>> runSolver(final DSLContext dbCtx,
-                                                           final Map<String, IRTable> irTables) {
+                                                           final Map<String, IRTable> irTables,
+                                                           final Map<String, Result<? extends Record>> inputRecords) {
+        generateDataCode(irTables, inputRecords);
         final String output = runMnzSolver(solverToUse);
         return parseMnzOutput(dbCtx, irTables, output);
     }
@@ -187,13 +189,12 @@ public class MinizincSolver implements ISolverBackend {
                                                    constraintViewCode, objectiveFunctionsCode));
     }
 
-    @Override
-    public List<String> generateDataCode(final IRContext context,
+    public List<String> generateDataCode(final Map<String, IRTable> irTables,
                                          final Map<String, Result<? extends Record>> records) {
         final List<String> ret = new ArrayList<>();
         final Map<String, List<String>> templateVars = new HashMap<>();
         final Set<String> stringLiterals = new HashSet<>(stringLiteralsInModel);
-        for (final IRTable table: context.getTables()) {
+        for (final IRTable table: irTables.values()) {
             if (table.isViewTable() || table.isAliasedTable()) {
                 continue;
             }

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -56,7 +56,6 @@ import com.vmware.dcm.compiler.ir.Qualifier;
 import com.vmware.dcm.compiler.ir.TableRowGenerator;
 import com.vmware.dcm.compiler.ir.UnaryOperator;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;
 import org.slf4j.Logger;
@@ -205,8 +204,7 @@ public class OrToolsSolver implements ISolverBackend {
     }
 
     @Override
-    public Map<String, Result<? extends Record>> runSolver(final DSLContext dbCtx,
-                                                           final Map<String, IRTable> irTables,
+    public Map<String, Result<? extends Record>> runSolver(final Map<String, IRTable> irTables,
                                                            final Map<String, Result<? extends Record>> inputRecords) {
         Preconditions.checkNotNull(generatedBackend);
         return generatedBackend.solve(inputRecords);

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -204,8 +204,7 @@ public class OrToolsSolver implements ISolverBackend {
     }
 
     @Override
-    public Map<String, Result<? extends Record>> runSolver(final Map<String, IRTable> irTables,
-                                                           final Map<String, Result<? extends Record>> inputRecords) {
+    public Map<String, Result<? extends Record>> runSolver(final Map<String, Result<? extends Record>> inputRecords) {
         Preconditions.checkNotNull(generatedBackend);
         return generatedBackend.solve(inputRecords);
     }

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -207,10 +207,10 @@ public class OrToolsSolver implements ISolverBackend {
 
     @Override
     public Map<String, Result<? extends Record>> runSolver(final DSLContext dbCtx,
-                                                            final Map<String, IRTable> irTables) {
+                                                           final Map<String, IRTable> irTables,
+                                                           final Map<String, Result<? extends Record>> inputRecords) {
         Preconditions.checkNotNull(generatedBackend);
-        Preconditions.checkNotNull(data);
-        return generatedBackend.solve(data);
+        return generatedBackend.solve(inputRecords);
     }
 
     /**
@@ -1091,12 +1091,6 @@ public class OrToolsSolver implements ISolverBackend {
                       | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public List<String> generateDataCode(final IRContext context, final Map<String, Result<? extends Record>> records) {
-        this.data = records;
-        return Collections.emptyList();
     }
 
     @Override

--- a/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
+++ b/dcm/src/main/java/com/vmware/dcm/backend/ortools/OrToolsSolver.java
@@ -123,7 +123,6 @@ public class OrToolsSolver implements ISolverBackend {
     }
 
     @Nullable private IGeneratedBackend generatedBackend;
-    @Nullable private Map<String, Result<? extends Record>> data = null;
 
     private OrToolsSolver(final int configNumThreads, final int configMaxTimeInSeconds,
                           final boolean configTryScalarProductEncoding,

--- a/dcm/src/test/java/com/vmware/dcm/ModelTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/ModelTest.java
@@ -66,7 +66,7 @@ public class ModelTest {
         final Field<Integer> f1 = field("C1", Integer.class);
         final Field<Integer> f2 = field("CONTROLLABLE__C2", Integer.class);
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, "testWithUpdateData");
-        Function<Table<?>, Result<? extends Record>> fetcher = (table) -> {
+        final Function<Table<?>, Result<? extends Record>> fetcher = (table) -> {
             final Result<Record2<Integer, Integer>> result = conn.newResult(f1, f2);
             final Record2<Integer, Integer> record1 = conn.newRecord(f1, f2);
             record1.setValue(f1, 78);
@@ -102,14 +102,13 @@ public class ModelTest {
         conn.execute("insert into pod values (3, null)");
 
         final int minimumPodId = 7;
-        model.updateData((table) -> {
+        final Result<? extends Record> result = model.solve("POD", (table) -> {
             if (table.getName().equalsIgnoreCase("pod")) {
                 // Should only pull in the 2nd record
                 return conn.selectFrom(table).where(field("pod_id").gt(minimumPodId)).fetch();
             }
             return conn.selectFrom(table).fetch();
         });
-        final Result<? extends Record> result = model.solve("POD");
         assertEquals(result.size(), 1);
         assertEquals(result.get(0).get(0), 10);
         assertEquals(result.get(0).get(1), 10);
@@ -138,7 +137,6 @@ public class ModelTest {
         conn.execute("insert into t2 values (1, 10)");
         conn.execute("insert into t2 values (2, 10)");
 
-        model.updateData();
         final Result<? extends Record> fetch = model.solve("T2");
         System.out.println(fetch);
         assertEquals(2, fetch.size());
@@ -167,7 +165,6 @@ public class ModelTest {
         conn.execute("insert into t1 values (1, 123)");
         conn.execute("insert into t1 values (2, 425)");
 
-        model.updateData();
         final Result<? extends Record> fetch = model.solve("T1");
         System.out.println(fetch);
         assertEquals(2, fetch.size());
@@ -201,7 +198,6 @@ public class ModelTest {
         conn.execute("insert into t1 values (3, 3, 19)");
         conn.execute("insert into t1 values (4, 4, 19)");
 
-        model.updateData();
         final Result<? extends Record> fetch = model.solve("T1");
         System.out.println(fetch);
         assertEquals(4, fetch.size());
@@ -227,7 +223,6 @@ public class ModelTest {
         conn.execute("insert into t1 values (3, null)");
 
         final Model model = Model.build(conn, List.of(all_different, domain));
-        model.updateData();
 
         final Result<? extends Record> results = model.solve("T1");
         final Set<Integer> controllableVars = results.stream().map(e -> e.get("CONTROLLABLE__VAR", Integer.class))
@@ -255,7 +250,6 @@ public class ModelTest {
         conn.execute("insert into t1 values (3, null)");
 
         final Model model = Model.build(conn, List.of(constraint_where1, constraint_where2, domain));
-        model.updateData();
 
         final Result<? extends Record> results = model.solve("T1");
         final List<Integer> controllableVars = results.stream().map(e -> e.get("CONTROLLABLE__VAR", Integer.class))
@@ -288,8 +282,6 @@ public class ModelTest {
 
         final Model model = Model.build(conn, List.of(constraintWhere1, constraintAllDifferent,
                                                       constraintWhere2, domain));
-        model.updateData();
-
         final Result<? extends Record> results = model.solve("T1");
         final List<Integer> controllableVars = results.stream().map(e -> e.get("CONTROLLABLE__VAR", Integer.class))
                 .collect(Collectors.toList());
@@ -316,7 +308,6 @@ public class ModelTest {
         conn.execute("insert into placement values (10)");
         conn.execute("insert into placement values (10)");
 
-        model.updateData();
         final Result<? extends Record> placement = model.solve("PLACEMENT");
         assertEquals(4, placement.size());
         placement.forEach(e -> assertEquals(1, e.get(0)));
@@ -385,9 +376,6 @@ public class ModelTest {
         conn.execute("insert into STRIPES values (3,'h1')");
         conn.execute("insert into STRIPES values (3,'h2')");
 
-        // update and solve
-        model.updateData();
-
         final List<String> results = model.solve("STRIPES")
                 .map(e -> e.get("CONTROLLABLE__HOST_ID", String.class));
 
@@ -437,9 +425,6 @@ public class ModelTest {
         conn.execute("insert into STRIPES values (2,'h3')");
         conn.execute("insert into STRIPES values (3,'h1')");
         conn.execute("insert into STRIPES values (3,'h3')");
-
-        // update and solve
-        model.updateData();
 
         final List<String> results = model.solve("STRIPES")
                 .map(e -> e.get("CONTROLLABLE__HOST_ID", String.class));
@@ -492,8 +477,6 @@ public class ModelTest {
         conn.execute("insert into STRIPES values (3,'h1')");
         conn.execute("insert into STRIPES values (3,'h2')");
 
-        // update and solve
-        model.updateData();
         final List<String> results = model.solve("STRIPES")
                 .map(e -> e.get("CONTROLLABLE__HOST_ID", String.class));
 
@@ -569,9 +552,7 @@ public class ModelTest {
         conn.execute("insert into HOSTS values ('h1', 3)");
         conn.execute("insert into HOSTS values ('h2', 3)");
 
-        // TODO: Strange
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -609,9 +590,7 @@ public class ModelTest {
         conn.execute("insert into HOSTS values ('h2', 2)");
         conn.execute("insert into HOSTS values ('h3', 3)");
 
-        // TODO: strange
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -642,7 +621,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
 
         final List<Integer> results = model.solve("T1")
                 .map(e -> e.get("CONTROLLABLE__C2", int.class));
@@ -676,7 +654,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         final List<Integer> results = model.solve("T1")
                 .map(e -> e.get("CONTROLLABLE__C2", int.class));
 
@@ -755,7 +732,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -787,7 +763,6 @@ public class ModelTest {
         conn.execute("insert into HOSTS values ('h3', 3)");
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -813,7 +788,6 @@ public class ModelTest {
         conn.execute("insert into HOSTS values ('h3', 3)");
 
         final Model model = Model.build(conn, views);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -845,8 +819,6 @@ public class ModelTest {
         conn.execute("insert into t2 values (3)");
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
-
         final List<Integer> fetch = model.solve("T1").map(e -> e.get("CONTROLLABLE__C1", Integer.class));
         assertEquals(1, fetch.size());
         assertEquals(3, fetch.get(0).intValue());
@@ -866,7 +838,6 @@ public class ModelTest {
                                                "SELECT * FROM t1 check exists(select c1 from t2 " +
                                                                               "where t2.c1 = t1.controllable__c1)");
             final Model model = Model.build(conn, views);
-            model.updateData();
             final List<Integer> fetch = model.solve("T1").map(e -> e.get("CONTROLLABLE__C1", Integer.class));
             assertEquals(2, fetch.size());
             assertTrue(List.of(2, 3).containsAll(fetch));
@@ -875,7 +846,6 @@ public class ModelTest {
             final List<String> views = List.of("CREATE VIEW constraint_t1 AS " +
                                                "SELECT * FROM t1 check all_different(controllable__c1)");
             final Model model = Model.build(conn, views);
-            model.updateData();
             final List<Integer> fetch = model.solve("T1").map(e -> e.get("CONTROLLABLE__C1", Integer.class));
             assertEquals(2, fetch.size());
             assertNotSame(fetch.get(0), fetch.get(1));
@@ -884,7 +854,6 @@ public class ModelTest {
             final List<String> views = List.of("CREATE VIEW constraint_t1 AS " +
                                                "SELECT * FROM t1 check all_equal(controllable__c1)");
             final Model model = Model.build(conn, views);
-            model.updateData();
             final List<Integer> fetch = model.solve("T1").map(e -> e.get("CONTROLLABLE__C1", Integer.class));
             assertEquals(2, fetch.size());
             assertEquals(fetch.get(0), fetch.get(1));
@@ -916,7 +885,6 @@ public class ModelTest {
         conn.execute("insert into HOSTS values ('h3', 3)");
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -964,7 +932,6 @@ public class ModelTest {
         conn.execute("insert into pod_ports_request values ('p1', '127.0.0.1', 1841, 'tcp')");
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -1004,7 +971,6 @@ public class ModelTest {
         conn.execute("insert into pod_info values ('p1', 'Pending', 1, 5)");
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -1031,7 +997,6 @@ public class ModelTest {
         conn.execute("insert into t1 values (1, ARRAY[100])");
 
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, modelName);
-        model.updateData();
 
         final List<Integer> fetch = model.solve("T1").getValues("CONTROLLABLE__C1", Integer.class);
         assertEquals(1, fetch.size());
@@ -1066,10 +1031,8 @@ public class ModelTest {
                 "SELECT * FROM int_view " +
                 "GROUP BY c2 " +
                 "maximize min(total)";
-
         final Model model = Model.build(conn, List.of(intermediateView, objective));
-        model.updateData();
-
+        assertEquals(model.solve("T1").intoSet(0), Set.of(1, 2));
     }
 
     @Test
@@ -1093,7 +1056,6 @@ public class ModelTest {
         conn.execute("insert into t1 values (1, 1)");
 
         final Model model = Model.build(conn, views);
-        model.updateData();
 
         final List<Integer> fetch = model.solve("T1").getValues("CONTROLLABLE__C1", Integer.class);
         assertEquals(1, fetch.size());
@@ -1146,7 +1108,6 @@ public class ModelTest {
         }
 
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, "capacity");
-        model.updateData();
         if (exception != null) {
             assertThrows(exception, () -> model.solve("t2"));
         } else {
@@ -1195,7 +1156,6 @@ public class ModelTest {
         conn.execute("insert into t2 values (1)");
         conn.execute("insert into t2 values (2)");
         final Model model = buildModel(conn, solver, Collections.singletonList(pod_info_constant), modelName);
-        model.updateData();
         final Result<? extends Record> t1 = model.solve("T1");
         assertEquals(1, t1.get(0).get("CONTROLLABLE__C2"));
         assertEquals(2, t1.get(1).get("CONTROLLABLE__C2"));
@@ -1241,7 +1201,6 @@ public class ModelTest {
             conn.execute(String.format("insert into pod_info values ('p%s', 'Pending', 'n1', 5)", i));
         }
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -1273,7 +1232,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -1317,7 +1275,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -1361,7 +1318,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -1414,7 +1370,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -1437,7 +1392,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, "testConstSums");
-        model.updateData();
         model.solve("t1");
     }
 
@@ -1480,7 +1434,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("HOSTS");
     }
 
@@ -1505,7 +1458,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("T1");
     }
 
@@ -1530,7 +1482,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
 
         final List<Integer> fetch = model.solve("T1").map(e -> e.get("CONTROLLABLE__C1", Integer.class));
         assertEquals(1, fetch.size());
@@ -1578,7 +1529,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         final Result<? extends Record> podInfo = model.solve("POD_INFO");
         podInfo.forEach(
                 e -> assertTrue(e.get("CONTROLLABLE__NODE_NAME").equals("n1") ||
@@ -1625,7 +1575,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -1663,7 +1612,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
 
         final Result<? extends Record> podInfo = model.solve("POD_INFO");
         assertEquals(1, podInfo.size());
@@ -1686,7 +1634,6 @@ public class ModelTest {
         final List<String> views = List.of("create view c1 as select * from t1 " +
                                            "check status != 'Pending' or controllable__id = 42");
         final Model model = Model.build(conn, views);
-        model.updateData();
         final Result<? extends Record> t1 = model.solve("T1");
         assertEquals(42, t1.get(0).get(1));
     }
@@ -1734,7 +1681,6 @@ public class ModelTest {
         }
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         final Result<? extends Record> results = model.solve("LEAST_REQUESTED");
         assertNull(results);
     }
@@ -1788,7 +1734,6 @@ public class ModelTest {
         );
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -1849,7 +1794,6 @@ public class ModelTest {
             "  sum(pod_info.pods_request) < node_info.pods_allocatable;");
 
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         model.solve("POD_INFO");
     }
 
@@ -2069,7 +2013,6 @@ public class ModelTest {
         );
         final List<String> views = toListOfViews(stringBuilder.toString());
         final Model model = buildModel(conn, solver, views, modelName);
-        model.updateData();
         assertThrows(SolverException.class, () -> model.solve("POD_INFO"));
     }
 
@@ -2200,7 +2143,6 @@ public class ModelTest {
 
         // build model
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, modelName);
-        model.updateData();
         model.solve(Set.of("HOSTS", "STRIPES"));
     }
 
@@ -2225,7 +2167,6 @@ public class ModelTest {
 
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, modelName);
 
-        model.updateData();
         final Result<? extends Record> fetch = model.solve("T1");
         System.out.println(fetch);
     }

--- a/dcm/src/test/java/com/vmware/dcm/ModelTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/ModelTest.java
@@ -15,6 +15,7 @@ import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Record2;
 import org.jooq.Result;
+import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,7 +66,7 @@ public class ModelTest {
         final Field<Integer> f1 = field("C1", Integer.class);
         final Field<Integer> f2 = field("CONTROLLABLE__C2", Integer.class);
         final Model model = buildModel(conn, SolverConfig.OrToolsSolver, views, "testWithUpdateData");
-        model.updateData((table) -> {
+        Function<Table<?>, Result<? extends Record>> fetcher = (table) -> {
             final Result<Record2<Integer, Integer>> result = conn.newResult(f1, f2);
             final Record2<Integer, Integer> record1 = conn.newRecord(f1, f2);
             record1.setValue(f1, 78);
@@ -75,8 +77,8 @@ public class ModelTest {
             record2.setValue(f2, 91); // will get over-written by constraint
             result.add(record2);
             return result;
-        });
-        final Result<? extends Record> result = model.solve("T1");
+        };
+        final Result<? extends Record> result = model.solve("T1", fetcher);
         assertEquals(result.get(0).get(0), 78);
         assertEquals(result.get(0).get(1), 78);
         assertEquals(result.get(1).get(0), 84);

--- a/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
+++ b/dcm/src/test/java/com/vmware/dcm/backend/ortools/CoreTest.java
@@ -147,7 +147,6 @@ public class CoreTest {
                 "select * from t1 check id != 1 or controllable__var = 1";
 
         final Model model = Model.build(conn, List.of(allDifferent, domain1, domain2));
-        model.updateData();
         try {
             model.solve("T1");
             fail();
@@ -178,7 +177,6 @@ public class CoreTest {
                 "select * from t1 check id != 1 or controllable__var = 1";
 
         final Model model = Model.build(conn, List.of(sum, domain1, domain2));
-        model.updateData();
         try {
             model.solve("T1");
             fail();

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -48,16 +48,13 @@ Start reading from the
    `LoadBalance.addPhysicalMachine()`).
 
 3. To actually run the load balancer, we simply invoke `LoadBalance.run()`, which uses two key methods from the DCM
-   Model API -- `model.updateData()` and `model.solve()`:
+   Model API -- `model.solve()`:
 
-   <!-- embedme ../examples/src/main/java/com/vmware/dcm/examples/LoadBalance.java#L78-L85 -->
+   <!-- embedme ../examples/src/main/java/com/vmware/dcm/examples/LoadBalance.java#L78-L82 -->
    ```java
    Result<? extends Record> run() {
-       // Pull the latest state from the DB
-       model.updateData();
-   
-       // Run the solver and return the virtual machines table with solver-identified values for the
-       // controllable__physical_machines column
+       // Pull the latest state from the DB, run the solver and return the virtual machines table with
+       // solver-identified values for the controllable__physical_machines column
        return model.solve(VIRTUAL_MACHINES_TABLE);
    }
    ```

--- a/examples/src/main/java/com/vmware/dcm/examples/LoadBalance.java
+++ b/examples/src/main/java/com/vmware/dcm/examples/LoadBalance.java
@@ -76,11 +76,8 @@ class LoadBalance {
      * @return The new virtual machine table after the solver identifies a new placement.
      */
     Result<? extends Record> run() {
-        // Pull the latest state from the DB
-        model.updateData();
-
-        // Run the solver and return the virtual machines table with solver-identified values for the
-        // controllable__physical_machines column
+        // Pull the latest state from the DB, run the solver and return the virtual machines table with
+        // solver-identified values for the controllable__physical_machines column
         return model.solve(VIRTUAL_MACHINES_TABLE);
     }
 

--- a/examples/src/test/java/com/vmware/dcm/examples/QuickStartTest.java
+++ b/examples/src/test/java/com/vmware/dcm/examples/QuickStartTest.java
@@ -48,9 +48,6 @@ public class QuickStartTest {
         // Create a DCM model using the database connection and the above constraint
         final Model model = Model.build(conn, List.of(constraint));
 
-        // Sync the model with the current data in the database
-        model.updateData();
-
         // Solve and return the tasks table. The controllable__worker_id column will either be [1, 5] or [5, 1]
         final List<Integer> column = model.solve("TASKS")
                 .map(e -> e.get("CONTROLLABLE__WORKER_ID", Integer.class));

--- a/k8s-scheduler/src/main/java/com/vmware/dcm/Scheduler.java
+++ b/k8s-scheduler/src/main/java/com/vmware/dcm/Scheduler.java
@@ -11,6 +11,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.vmware.dcm.backend.minizinc.MinizincSolver;
+import com.vmware.dcm.backend.ortools.OrToolsSolver;
+import com.vmware.dcm.k8s.generated.Tables;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.cli.CommandLine;
@@ -18,8 +20,6 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import com.vmware.dcm.backend.ortools.OrToolsSolver;
-import com.vmware.dcm.k8s.generated.Tables;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;
@@ -61,7 +61,6 @@ public final class Scheduler {
     private final AtomicInteger batchId = new AtomicInteger(0);
     private final MetricRegistry metrics = new MetricRegistry();
     private final Meter solverInvocations = metrics.meter("solverInvocations");
-    private final Timer updateDataTimes = metrics.timer(name(Scheduler.class, "updateDataTimes"));
     private final Timer solveTimes = metrics.timer(name(Scheduler.class, "solveTimes"));
     private final ThreadFactory namedThreadFactory =
             new ThreadFactoryBuilder().setNameFormat("computation-thread-%d").build();
@@ -166,9 +165,6 @@ public final class Scheduler {
     }
 
     Result<? extends Record> runOneLoop() {
-        final Timer.Context updateDataTimer = updateDataTimes.time();
-        model.updateData();
-        updateDataTimer.stop();
         final Timer.Context solveTimer = solveTimes.time();
         final Result<? extends Record> podsToAssignUpdated = model.solve("PODS_TO_ASSIGN");
         solveTimer.stop();


### PR DESCRIPTION
`model.updateData()` was always called just before invoking `model.solve()`, a clear sign that they shouldn't be two separate calls to begin with. This patch folds the equivalent functionality into `model.solve()`, and also adds overloaded versions to support a custom fetcher.

In doing so, it became clear that the internal APIs to interact with the solvers did not need an explicit `ISolverBackend.generateDataCode()` phase either. The patch further simplifies the interaction with the solvers, making it such that once model generation is done, the only argument required to invoke the solver is a set of tables.

These changes combine to make the `Model` instance and the solver backend completely stateless.