### PR TITLE
Framework writing scheduler tests

### DIFF
--- a/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/SchedulerTest.java
@@ -62,6 +62,7 @@ import static com.vmware.dcm.TestScenario.Op.COLOCATED_WITH;
 import static com.vmware.dcm.TestScenario.Op.EQUALS;
 import static com.vmware.dcm.TestScenario.Op.IN;
 import static com.vmware.dcm.TestScenario.Op.NOT_COLOCATED_WITH;
+import static com.vmware.dcm.TestScenario.Op.NOT_EQUALS;
 import static com.vmware.dcm.TestScenario.Op.NOT_IN;
 import static com.vmware.dcm.TestScenario.nodeGroup;
 import static com.vmware.dcm.TestScenario.nodesForPodGroup;
@@ -462,7 +463,10 @@ public class SchedulerTest {
                 .runInitialPlacement();
         if (cannotBePlacedAnywhere) {
             result.expect(nodesForPodGroup("withConstraint"), EQUALS, nodeGroup("NULL_NODE"));
-        } else if (condition.equals("Affinity")) {
+            return;
+        }
+        result.expect(nodesForPodGroup("withConstraint"), NOT_EQUALS, nodeGroup("NULL_NODE"));
+        if (condition.equals("Affinity")) {
             final boolean affineToLabelledPods = conditionToLabelledPods;
             final boolean affineToRemainingPods = conditionToRemainingPods;
             if (affineToLabelledPods && affineToRemainingPods) {
@@ -488,7 +492,7 @@ public class SchedulerTest {
     }
 
     @SuppressWarnings("UnusedMethod")
-    private static Stream testPodAffinity() {
+    private static Stream<Arguments> testPodAffinity() {
         final String topologyKey = "kubernetes.io/hostname";
         final List<PodAffinityTerm> inTerm = List.of(term(topologyKey,
                                                        podExpr("k1", "In", "l1", "l2")));
@@ -562,21 +566,23 @@ public class SchedulerTest {
                 argGen("AntiAffinity", existsTerm, map("k", "l", "k2", "l2"), false, false, false),
                 argGen("AntiAffinity", existsTerm, map("k", "l", "k2", "l3"), false, false, false),
 
+                // TODO: The following tests need to be revisited, as they always lead (correctly)
+                //       to NULL_NODE assignments for the labelled pods
                 // NotIn
-                argGen("AntiAffinity", notInTerm, map("k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notInTerm, map("k1", "l2"), false, false, false),
+                argGen("AntiAffinity", notInTerm, map("k1", "l1"), false, false, true),
+                argGen("AntiAffinity", notInTerm, map("k1", "l2"), false, false, true),
                 argGen("AntiAffinity", notInTerm, map("k1", "l3"), false, false, true),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l1"), false, false, false),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l1"), false, false, true),
                 argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l3"), false, false, true),
-                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l2"), false, false, false),
+                argGen("AntiAffinity", notInTerm, map("k", "l", "k1", "l2"), false, false, true),
 
                 // DoesNotExist
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l2"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k1", "l3"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, false, false),
-                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, false, false)
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l1"), false, false, true),
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l2"), false, false, true),
+                argGen("AntiAffinity", notExistsTerm, map("k1", "l3"), false, false, true),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l1"), false, false, true),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l2"), false, false, true),
+                argGen("AntiAffinity", notExistsTerm, map("k", "l", "k1", "l3"), false, false, true)
         );
     }
 

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/TestScenario.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/TestScenario.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A simple DSL to set up scheduling scenarios for testing
  */
 class TestScenario {
-    private final DBConnectionPool dbConnectionPool = new DBConnectionPool();
+    final DBConnectionPool dbConnectionPool = new DBConnectionPool();
     private final Scheduler.Builder schedulerBuilder = new Scheduler.Builder(dbConnectionPool);
     private final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
     private final NodeResourceEventHandler nodeResourceEventHandler = new NodeResourceEventHandler(dbConnectionPool);

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/TestScenario.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/TestScenario.java
@@ -103,7 +103,7 @@ class TestScenario {
     }
 
     static class TestResult {
-        private final Result<? extends Record> results;
+        final Result<? extends Record> results;
         private final List<Node> nodes;
 
         private TestResult(final Result<? extends Record> result, final List<Node> nodes) {
@@ -165,6 +165,9 @@ class TestScenario {
                 case EQUALS:
                     assertEquals(expected, actual, String.format("Failed: %s == %s", actual, expected));
                     break;
+                case NOT_EQUALS:
+                    assertNotEquals(expected, actual, String.format("Failed: %s == %s", actual, expected));
+                    break;
                 case IN:
                     assertTrue(expected.containsAll(actual),
                                String.format("Failed: %s IN %s", actual, expected));
@@ -184,6 +187,7 @@ class TestScenario {
         NOT_COLOCATED_WITH,
         COLOCATED_WITH,
         EQUALS,
+        NOT_EQUALS,
         IN,
         NOT_IN
     }

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/TestScenario.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/TestScenario.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2018-2021 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.jooq.Record;
+import org.jooq.Result;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static com.vmware.dcm.SchedulerTest.newNode;
+import static com.vmware.dcm.SchedulerTest.newPod;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * A simple DSL to set up scheduling scenarios for testing
+ */
+class TestScenario {
+    private final DBConnectionPool dbConnectionPool = new DBConnectionPool();
+    private final Scheduler.Builder schedulerBuilder = new Scheduler.Builder(dbConnectionPool);
+    private final PodEventsToDatabase eventHandler = new PodEventsToDatabase(dbConnectionPool);
+    private final NodeResourceEventHandler nodeResourceEventHandler = new NodeResourceEventHandler(dbConnectionPool);
+    private final PodResourceEventHandler podResourceEventHandler = new PodResourceEventHandler(eventHandler::handle);
+    private final Set<String> podGroups = new HashSet<>();
+    private final Set<String> nodeGroups = new HashSet<>();
+    private final List<Pod> pods = new ArrayList<>();
+    private final List<Node> nodes = new ArrayList<>();
+    @Nullable
+    Scheduler scheduler;
+
+    static TestScenario withInitialPlacementPolicies(final List<String> policies) {
+        final var scenario = new TestScenario();
+        scenario.schedulerBuilder.setInitialPlacementPolicies(policies);
+        scenario.scheduler = scenario.schedulerBuilder.build();
+        return scenario;
+    }
+
+    TestScenario withPodGroup(final String groupName, final int numPods, final Consumer<Pod>... modifiers) {
+        if (podGroups.contains(groupName)) {
+            throw new IllegalArgumentException("Pod group already exists: " + groupName);
+        }
+        podGroups.add(groupName);
+        for (int i = 0; i < numPods; i++) {
+            final Pod pod = newPod(groupName + "-" + UUID.randomUUID());
+            for (final var modifier : modifiers) {
+                modifier.accept(pod);
+            }
+            pods.add(pod);
+            podResourceEventHandler.onAddSync(pod);
+        }
+        return this;
+    }
+
+    TestScenario withNodeGroup(final String groupName, final int numNodes, final Consumer<Node>... modifiers) {
+        if (nodeGroups.contains(groupName)) {
+            throw new IllegalArgumentException("Node group already exists: " + groupName);
+        }
+        nodeGroups.add(groupName);
+        for (int i = 0; i < numNodes; i++) {
+            final Node node = newNode(groupName + "-" + UUID.randomUUID(),
+                                      Collections.emptyMap(), Collections.emptyList());
+            for (final var modifier : modifiers) {
+                modifier.accept(node);
+            }
+            nodes.add(node);
+            nodeResourceEventHandler.onAddSync(node);
+        }
+        return this;
+    }
+
+    TestResult runInitialPlacement() {
+        assertNotNull(scheduler);
+        return new TestResult(scheduler.initialPlacement(), nodes);
+    }
+
+    static PodGroup podGroup(final String... name) {
+        return new PodGroup(name);
+    }
+
+    static NodesForPodGroup nodesForPodGroup(final String name) {
+        return new NodesForPodGroup(name);
+    }
+
+    static NodeGroup nodeGroup(final String... names) {
+        return new NodeGroup(names);
+    }
+
+    static class TestResult {
+        private final Result<? extends Record> results;
+        private final List<Node> nodes;
+
+        private TestResult(final Result<? extends Record> result, final List<Node> nodes) {
+            this.results = result;
+            this.nodes = nodes;
+        }
+
+        public TestResult expect(final PodGroup leftGroup, final Op op, final PodGroup rightGroup) {
+            assert op == Op.COLOCATED_WITH || op == Op.NOT_COLOCATED_WITH;
+            assertEquals(1, leftGroup.names.size());
+            results.stream()
+                   .filter(r -> r.get("POD_NAME", String.class).startsWith(leftGroup.names.get(0) + "-"))
+                   .forEach(leftGroupRow -> {
+                            final String leftPodName = leftGroupRow.get("POD_NAME", String.class);
+                            final String leftNodeName = leftGroupRow.get("CONTROLLABLE__NODE_NAME", String.class);
+                            assertNotEquals("NULL_NODE", leftNodeName);
+                            final Set<String> otherNodes = results.stream()
+                                   .filter(e -> {
+                                       for (final var groupName: rightGroup.names) {
+                                           if (e.get("POD_NAME", String.class).startsWith(groupName + "-")) {
+                                               return true;
+                                           }
+                                       }
+                                       return false;
+                                   })
+                                   .filter(e -> !e.get("POD_NAME", String.class).equals(leftPodName))
+                                   .map(e -> e.get("CONTROLLABLE__NODE_NAME", String.class))
+                                   .collect(Collectors.toSet());
+                            if (op == Op.COLOCATED_WITH) {
+                                assertTrue(otherNodes.contains(leftNodeName), leftNodeName + " " + otherNodes);
+                            } else {
+                                assertFalse(otherNodes.contains(leftNodeName));
+                            }
+                       }
+                   );
+            return this;
+        }
+
+        public TestResult expect(final NodesForPodGroup podGroup, final Op op, final NodeGroup nodeGroup) {
+            final Set<String> actual = results.stream()
+                    .filter(e -> e.get("POD_NAME", String.class).startsWith(podGroup.name + "-"))
+                    .map(e -> e.get("CONTROLLABLE__NODE_NAME", String.class))
+                    .collect(Collectors.toSet());
+            final Set<String> expected = nodes.stream()
+                    .map(node -> node.getMetadata().getName())
+                    .filter(nodeName -> {
+                        for (final var groupName: nodeGroup.names) {
+                            if (nodeName.startsWith(groupName + "-")) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    })
+                    .collect(Collectors.toSet());
+            if (nodeGroup.names.contains("NULL_NODE")) {
+                expected.add("NULL_NODE");
+            }
+            switch (op) {
+                case EQUALS:
+                    assertEquals(expected, actual, String.format("Failed: %s == %s", actual, expected));
+                    break;
+                case IN:
+                    assertTrue(expected.containsAll(actual),
+                               String.format("Failed: %s IN %s", actual, expected));
+                    break;
+                case NOT_IN:
+                    assertFalse(expected.containsAll(actual),
+                                String.format("Failed: %s NOT IN %s", actual, expected));
+                    break;
+                default:
+                    throw new IllegalArgumentException(op.toString());
+            }
+            return this;
+        }
+    }
+
+    enum Op {
+        NOT_COLOCATED_WITH,
+        COLOCATED_WITH,
+        EQUALS,
+        IN,
+        NOT_IN
+    }
+
+    static class PodGroup {
+        private final List<String> names;
+
+        PodGroup(final String... name) {
+            assertNotEquals(0, name.length);
+            this.names = Arrays.asList(name);
+        }
+    }
+
+    static class NodesForPodGroup {
+        private final String name;
+
+        NodesForPodGroup(final String name) {
+            this.name = name;
+        }
+    }
+
+    static class NodeGroup {
+        private final List<String> names;
+
+        NodeGroup(final String... name) {
+            assertNotEquals(0, name.length);
+            this.names = Arrays.asList(name);
+        }
+    }
+}

--- a/k8s-scheduler/src/test/java/com/vmware/dcm/UnbindTest.java
+++ b/k8s-scheduler/src/test/java/com/vmware/dcm/UnbindTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2018-2021 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.dcm;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.jupiter.api.AfterEach;
+
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class UnbindTest {
+    @Nullable
+    private KubernetesServer server;
+
+    @AfterEach
+    void tearDown() {
+        assertNotNull(server);
+        server.after();
+    }
+
+}


### PR DESCRIPTION
The new `Scenario` framework simplifies test cases dramatically. It allows the tests to focus on the scenario being tested and ignore the boilerplate of managing the types of nodes/pods, and instantiating the different objects required to bring up a scheduler.