### PR TITLE
Migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/k8s-scheduler/src/main/resources/pod-only.yml
+++ b/k8s-scheduler/src/main/resources/pod-only.yml
@@ -8,5 +8,5 @@ spec:
   schedulerName: default-scheduler
   containers:
     - name: cache
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
       imagePullPolicy: IfNotPresent

--- a/k8s-scheduler/src/main/resources/pod-with-affinity.yml
+++ b/k8s-scheduler/src/main/resources/pod-with-affinity.yml
@@ -8,7 +8,7 @@ spec:
   schedulerName: default-scheduler
   containers:
     - name: cache
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
       imagePullPolicy: IfNotPresent
   affinity:
     podAntiAffinity:

--- a/k8s-scheduler/src/test/resources/app-no-constraints.yml
+++ b/k8s-scheduler/src/test/resources/app-no-constraints.yml
@@ -15,5 +15,5 @@ spec:
       schedulerName: default-scheduler
       containers:
         - name: cache
-          image: k8s.gcr.io/pause
+          image: registry.k8s.io/pause
           imagePullPolicy: IfNotPresent

--- a/k8s-scheduler/src/test/resources/cache-example.yml
+++ b/k8s-scheduler/src/test/resources/cache-example.yml
@@ -25,5 +25,5 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: cache
-          image: k8s.gcr.io/pause
+          image: registry.k8s.io/pause
           imagePullPolicy: IfNotPresent

--- a/k8s-scheduler/src/test/resources/web-store-example.yml
+++ b/k8s-scheduler/src/test/resources/web-store-example.yml
@@ -34,5 +34,5 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: web-app
-          image: k8s.gcr.io/pause
+          image: registry.k8s.io/pause
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.